### PR TITLE
chore: update npm dependencies to latest minor versions

### DIFF
--- a/.jsii
+++ b/.jsii
@@ -20,7 +20,7 @@
     "yaml": "^2.8.0"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.194.0",
+    "aws-cdk-lib": "2.233.0",
     "constructs": "^10.0.0"
   },
   "dependencyClosure": {
@@ -170,6 +170,19 @@
             },
             "python": {
               "module": "aws_cdk.aws_acmpca"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_aiops": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AIOps"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.aiops"
+            },
+            "python": {
+              "module": "aws_cdk.aws_aiops"
             }
           }
         },
@@ -332,7 +345,7 @@
         "aws-cdk-lib.aws_applicationsignals": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.ApplicationSignals"
+              "namespace": "Amazon.CDK.AWS.ApplicationSignals"
             },
             "java": {
               "package": "software.amazon.awscdk.services.applicationsignals"
@@ -397,7 +410,7 @@
         "aws-cdk-lib.aws_apptest": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.AppTest"
+              "namespace": "Amazon.CDK.AWS.AppTest"
             },
             "java": {
               "package": "software.amazon.awscdk.services.apptest"
@@ -420,10 +433,23 @@
             }
           }
         },
+        "aws-cdk-lib.aws_arcregionswitch": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ARCRegionSwitch"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.arcregionswitch"
+            },
+            "python": {
+              "module": "aws_cdk.aws_arcregionswitch"
+            }
+          }
+        },
         "aws-cdk-lib.aws_arczonalshift": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.ARCZonalShift"
+              "namespace": "Amazon.CDK.AWS.ARCZonalShift"
             },
             "java": {
               "package": "software.amazon.awscdk.services.arczonalshift"
@@ -514,7 +540,7 @@
         "aws-cdk-lib.aws_b2bi": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.B2BI"
+              "namespace": "Amazon.CDK.AWS.B2BI"
             },
             "java": {
               "package": "software.amazon.awscdk.services.b2bi"
@@ -540,7 +566,7 @@
         "aws-cdk-lib.aws_backupgateway": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.BackupGateway"
+              "namespace": "Amazon.CDK.AWS.BackupGateway"
             },
             "java": {
               "package": "software.amazon.awscdk.services.backupgateway"
@@ -566,7 +592,7 @@
         "aws-cdk-lib.aws_bcmdataexports": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.BCMDataExports"
+              "namespace": "Amazon.CDK.AWS.BCMDataExports"
             },
             "java": {
               "package": "software.amazon.awscdk.services.bcmdataexports"
@@ -579,13 +605,26 @@
         "aws-cdk-lib.aws_bedrock": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.Bedrock"
+              "namespace": "Amazon.CDK.AWS.Bedrock"
             },
             "java": {
               "package": "software.amazon.awscdk.services.bedrock"
             },
             "python": {
               "module": "aws_cdk.aws_bedrock"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_bedrockagentcore": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.BedrockAgentCore"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.bedrockagentcore"
+            },
+            "python": {
+              "module": "aws_cdk.aws_bedrockagentcore"
             }
           }
         },
@@ -670,7 +709,7 @@
         "aws-cdk-lib.aws_cleanrooms": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.CleanRooms"
+              "namespace": "Amazon.CDK.AWS.CleanRooms"
             },
             "java": {
               "package": "software.amazon.awscdk.services.cleanrooms"
@@ -683,7 +722,7 @@
         "aws-cdk-lib.aws_cleanroomsml": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.CleanRoomsML"
+              "namespace": "Amazon.CDK.AWS.CleanRoomsML"
             },
             "java": {
               "package": "software.amazon.awscdk.services.cleanroomsml"
@@ -827,7 +866,7 @@
         "aws-cdk-lib.aws_codeconnections": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.CodeConnections"
+              "namespace": "Amazon.CDK.AWS.CodeConnections"
             },
             "java": {
               "package": "software.amazon.awscdk.services.codeconnections"
@@ -1022,7 +1061,7 @@
         "aws-cdk-lib.aws_connectcampaignsv2": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.ConnectCampaignsV2"
+              "namespace": "Amazon.CDK.AWS.ConnectCampaignsV2"
             },
             "java": {
               "package": "software.amazon.awscdk.services.connectcampaignsv2"
@@ -1113,7 +1152,7 @@
         "aws-cdk-lib.aws_datazone": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.DataZone"
+              "namespace": "Amazon.CDK.AWS.DataZone"
             },
             "java": {
               "package": "software.amazon.awscdk.services.datazone"
@@ -1139,7 +1178,7 @@
         "aws-cdk-lib.aws_deadline": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.Deadline"
+              "namespace": "Amazon.CDK.AWS.Deadline"
             },
             "java": {
               "package": "software.amazon.awscdk.services.deadline"
@@ -1172,6 +1211,19 @@
             },
             "python": {
               "module": "aws_cdk.aws_devicefarm"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_devopsagent": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.DevOpsAgent"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.devopsagent"
+            },
+            "python": {
+              "module": "aws_cdk.aws_devopsagent"
             }
           }
         },
@@ -1256,7 +1308,7 @@
         "aws-cdk-lib.aws_dsql": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.DSQL"
+              "namespace": "Amazon.CDK.AWS.DSQL"
             },
             "java": {
               "package": "software.amazon.awscdk.services.dsql"
@@ -1503,7 +1555,7 @@
         "aws-cdk-lib.aws_entityresolution": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.EntityResolution"
+              "namespace": "Amazon.CDK.AWS.EntityResolution"
             },
             "java": {
               "package": "software.amazon.awscdk.services.entityresolution"
@@ -1562,6 +1614,19 @@
             },
             "python": {
               "module": "aws_cdk.aws_evidently"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_evs": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.EVS"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.evs"
+            },
+            "python": {
+              "module": "aws_cdk.aws_evs"
             }
           }
         },
@@ -1659,7 +1724,7 @@
         "aws-cdk-lib.aws_gameliftstreams": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.GameLiftStreams"
+              "namespace": "Amazon.CDK.AWS.GameLiftStreams"
             },
             "java": {
               "package": "software.amazon.awscdk.services.gameliftstreams"
@@ -1776,7 +1841,7 @@
         "aws-cdk-lib.aws_healthimaging": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.HealthImaging"
+              "namespace": "Amazon.CDK.AWS.HealthImaging"
             },
             "java": {
               "package": "software.amazon.awscdk.services.healthimaging"
@@ -1880,7 +1945,7 @@
         "aws-cdk-lib.aws_invoicing": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.Invoicing"
+              "namespace": "Amazon.CDK.AWS.Invoicing"
             },
             "java": {
               "package": "software.amazon.awscdk.services.invoicing"
@@ -2231,7 +2296,7 @@
         "aws-cdk-lib.aws_launchwizard": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.LaunchWizard"
+              "namespace": "Amazon.CDK.AWS.LaunchWizard"
             },
             "java": {
               "package": "software.amazon.awscdk.services.launchwizard"
@@ -2452,7 +2517,7 @@
         "aws-cdk-lib.aws_mediapackagev2": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.MediaPackageV2"
+              "namespace": "Amazon.CDK.AWS.MediaPackageV2"
             },
             "java": {
               "package": "software.amazon.awscdk.services.mediapackagev2"
@@ -2501,6 +2566,19 @@
             }
           }
         },
+        "aws-cdk-lib.aws_mpa": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.MPA"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.mpa"
+            },
+            "python": {
+              "module": "aws_cdk.aws_mpa"
+            }
+          }
+        },
         "aws-cdk-lib.aws_msk": {
           "targets": {
             "dotnet": {
@@ -2543,7 +2621,7 @@
         "aws-cdk-lib.aws_neptunegraph": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.NeptuneGraph"
+              "namespace": "Amazon.CDK.AWS.NeptuneGraph"
             },
             "java": {
               "package": "software.amazon.awscdk.services.neptunegraph"
@@ -2595,7 +2673,7 @@
         "aws-cdk-lib.aws_notifications": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.Notifications"
+              "namespace": "Amazon.CDK.AWS.Notifications"
             },
             "java": {
               "package": "software.amazon.awscdk.services.notifications"
@@ -2608,7 +2686,7 @@
         "aws-cdk-lib.aws_notificationscontacts": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.NotificationsContacts"
+              "namespace": "Amazon.CDK.AWS.NotificationsContacts"
             },
             "java": {
               "package": "software.amazon.awscdk.services.notificationscontacts"
@@ -2628,6 +2706,32 @@
             },
             "python": {
               "module": "aws_cdk.aws_oam"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_observabilityadmin": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ObservabilityAdmin"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.observabilityadmin"
+            },
+            "python": {
+              "module": "aws_cdk.aws_observabilityadmin"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_odb": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ODB"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.odb"
+            },
+            "python": {
+              "module": "aws_cdk.aws_odb"
             }
           }
         },
@@ -2712,7 +2816,7 @@
         "aws-cdk-lib.aws_osis": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.OSIS"
+              "namespace": "Amazon.CDK.AWS.OSIS"
             },
             "java": {
               "package": "software.amazon.awscdk.services.osis"
@@ -2738,7 +2842,7 @@
         "aws-cdk-lib.aws_paymentcryptography": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.PaymentCryptography"
+              "namespace": "Amazon.CDK.AWS.PaymentCryptography"
             },
             "java": {
               "package": "software.amazon.awscdk.services.paymentcryptography"
@@ -2751,7 +2855,7 @@
         "aws-cdk-lib.aws_pcaconnectorad": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.PCAConnectorAD"
+              "namespace": "Amazon.CDK.AWS.PCAConnectorAD"
             },
             "java": {
               "package": "software.amazon.awscdk.services.pcaconnectorad"
@@ -2764,7 +2868,7 @@
         "aws-cdk-lib.aws_pcaconnectorscep": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.PCAConnectorSCEP"
+              "namespace": "Amazon.CDK.AWS.PCAConnectorSCEP"
             },
             "java": {
               "package": "software.amazon.awscdk.services.pcaconnectorscep"
@@ -2777,7 +2881,7 @@
         "aws-cdk-lib.aws_pcs": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.PCS"
+              "namespace": "Amazon.CDK.AWS.PCS"
             },
             "java": {
               "package": "software.amazon.awscdk.services.pcs"
@@ -2842,7 +2946,7 @@
         "aws-cdk-lib.aws_proton": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.Proton"
+              "namespace": "Amazon.CDK.AWS.Proton"
             },
             "java": {
               "package": "software.amazon.awscdk.services.proton"
@@ -2855,7 +2959,7 @@
         "aws-cdk-lib.aws_qbusiness": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.QBusiness"
+              "namespace": "Amazon.CDK.AWS.QBusiness"
             },
             "java": {
               "package": "software.amazon.awscdk.services.qbusiness"
@@ -2907,7 +3011,7 @@
         "aws-cdk-lib.aws_rbin": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.Rbin"
+              "namespace": "Amazon.CDK.AWS.Rbin"
             },
             "java": {
               "package": "software.amazon.awscdk.services.rbin"
@@ -3089,7 +3193,7 @@
         "aws-cdk-lib.aws_route53profiles": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.Route53Profiles"
+              "namespace": "Amazon.CDK.AWS.Route53Profiles"
             },
             "java": {
               "package": "software.amazon.awscdk.services.route53profiles"
@@ -3135,6 +3239,19 @@
             },
             "python": {
               "module": "aws_cdk.aws_route53resolver"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_rtbfabric": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.RTBFabric"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.rtbfabric"
+            },
+            "python": {
+              "module": "aws_cdk.aws_rtbfabric"
             }
           }
         },
@@ -3206,7 +3323,7 @@
         "aws-cdk-lib.aws_s3express": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.S3Express"
+              "namespace": "Amazon.CDK.AWS.S3Express"
             },
             "java": {
               "package": "software.amazon.awscdk.services.s3express"
@@ -3245,13 +3362,26 @@
         "aws-cdk-lib.aws_s3tables": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.S3Tables"
+              "namespace": "Amazon.CDK.AWS.S3Tables"
             },
             "java": {
               "package": "software.amazon.awscdk.services.s3tables"
             },
             "python": {
               "module": "aws_cdk.aws_s3tables"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_s3vectors": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.S3Vectors"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.s3vectors"
+            },
+            "python": {
+              "module": "aws_cdk.aws_s3vectors"
             }
           }
         },
@@ -3349,7 +3479,7 @@
         "aws-cdk-lib.aws_securitylake": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.SecurityLake"
+              "namespace": "Amazon.CDK.AWS.SecurityLake"
             },
             "java": {
               "package": "software.amazon.awscdk.services.securitylake"
@@ -3427,7 +3557,7 @@
         "aws-cdk-lib.aws_shield": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.Shield"
+              "namespace": "Amazon.CDK.AWS.Shield"
             },
             "java": {
               "package": "software.amazon.awscdk.services.shield"
@@ -3460,6 +3590,19 @@
             },
             "python": {
               "module": "aws_cdk.aws_simspaceweaver"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_smsvoice": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SMSVOICE"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.smsvoice"
+            },
+            "python": {
+              "module": "aws_cdk.aws_smsvoice"
             }
           }
         },
@@ -3528,6 +3671,19 @@
             }
           }
         },
+        "aws-cdk-lib.aws_ssmguiconnect": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SSMGuiConnect"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.ssmguiconnect"
+            },
+            "python": {
+              "module": "aws_cdk.aws_ssmguiconnect"
+            }
+          }
+        },
         "aws-cdk-lib.aws_ssmincidents": {
           "targets": {
             "dotnet": {
@@ -3544,7 +3700,7 @@
         "aws-cdk-lib.aws_ssmquicksetup": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.SSMQuickSetup"
+              "namespace": "Amazon.CDK.AWS.SSMQuickSetup"
             },
             "java": {
               "package": "software.amazon.awscdk.services.ssmquicksetup"
@@ -3661,7 +3817,7 @@
         "aws-cdk-lib.aws_verifiedpermissions": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.VerifiedPermissions"
+              "namespace": "Amazon.CDK.AWS.VerifiedPermissions"
             },
             "java": {
               "package": "software.amazon.awscdk.services.verifiedpermissions"
@@ -3762,10 +3918,23 @@
             }
           }
         },
+        "aws-cdk-lib.aws_workspacesinstances": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.WorkspacesInstances"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.workspacesinstances"
+            },
+            "python": {
+              "module": "aws_cdk.aws_workspacesinstances"
+            }
+          }
+        },
         "aws-cdk-lib.aws_workspacesthinclient": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.WorkSpacesThinClient"
+              "namespace": "Amazon.CDK.AWS.WorkSpacesThinClient"
             },
             "java": {
               "package": "software.amazon.awscdk.services.workspacesthinclient"
@@ -3778,7 +3947,7 @@
         "aws-cdk-lib.aws_workspacesweb": {
           "targets": {
             "dotnet": {
-              "package": "Amazon.CDK.AWS.WorkSpacesWeb"
+              "namespace": "Amazon.CDK.AWS.WorkSpacesWeb"
             },
             "java": {
               "package": "software.amazon.awscdk.services.workspacesweb"
@@ -3838,6 +4007,4326 @@
             },
             "python": {
               "module": "aws_cdk.cx_api"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces"
+            },
+            "go": {
+              "packageName": "interfaces"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.alexa_ask": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Ask"
+            },
+            "go": {
+              "packageName": "interfacesalexaask"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.ask"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.alexa_ask"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_accessanalyzer": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AccessAnalyzer"
+            },
+            "go": {
+              "packageName": "interfacesawsaccessanalyzer"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.accessanalyzer"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_accessanalyzer"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_acmpca": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ACMPCA"
+            },
+            "go": {
+              "packageName": "interfacesawsacmpca"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.acmpca"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_acmpca"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_aiops": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AIOps"
+            },
+            "go": {
+              "packageName": "interfacesawsaiops"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.aiops"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_aiops"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_amazonmq": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AmazonMQ"
+            },
+            "go": {
+              "packageName": "interfacesawsamazonmq"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.amazonmq"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_amazonmq"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_amplify": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Amplify"
+            },
+            "go": {
+              "packageName": "interfacesawsamplify"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.amplify"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_amplify"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_amplifyuibuilder": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AmplifyUIBuilder"
+            },
+            "go": {
+              "packageName": "interfacesawsamplifyuibuilder"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.amplifyuibuilder"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_amplifyuibuilder"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_apigateway": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.APIGateway"
+            },
+            "go": {
+              "packageName": "interfacesawsapigateway"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.apigateway"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_apigateway"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_apigatewayv2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Apigatewayv2"
+            },
+            "go": {
+              "packageName": "interfacesawsapigatewayv2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.apigatewayv2"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_apigatewayv2"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_appconfig": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AppConfig"
+            },
+            "go": {
+              "packageName": "interfacesawsappconfig"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.appconfig"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_appconfig"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_appflow": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AppFlow"
+            },
+            "go": {
+              "packageName": "interfacesawsappflow"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.appflow"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_appflow"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_appintegrations": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AppIntegrations"
+            },
+            "go": {
+              "packageName": "interfacesawsappintegrations"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.appintegrations"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_appintegrations"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_applicationautoscaling": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ApplicationAutoScaling"
+            },
+            "go": {
+              "packageName": "interfacesawsapplicationautoscaling"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.applicationautoscaling"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_applicationautoscaling"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_applicationinsights": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ApplicationInsights"
+            },
+            "go": {
+              "packageName": "interfacesawsapplicationinsights"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.applicationinsights"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_applicationinsights"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_applicationsignals": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ApplicationSignals"
+            },
+            "go": {
+              "packageName": "interfacesawsapplicationsignals"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.applicationsignals"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_applicationsignals"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_appmesh": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AppMesh"
+            },
+            "go": {
+              "packageName": "interfacesawsappmesh"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.appmesh"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_appmesh"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_apprunner": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AppRunner"
+            },
+            "go": {
+              "packageName": "interfacesawsapprunner"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.apprunner"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_apprunner"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_appstream": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AppStream"
+            },
+            "go": {
+              "packageName": "interfacesawsappstream"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.appstream"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_appstream"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_appsync": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AppSync"
+            },
+            "go": {
+              "packageName": "interfacesawsappsync"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.appsync"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_appsync"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_apptest": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AppTest"
+            },
+            "go": {
+              "packageName": "interfacesawsapptest"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.apptest"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_apptest"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_aps": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.APS"
+            },
+            "go": {
+              "packageName": "interfacesawsaps"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.aps"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_aps"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_arcregionswitch": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ARCRegionSwitch"
+            },
+            "go": {
+              "packageName": "interfacesawsarcregionswitch"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.arcregionswitch"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_arcregionswitch"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_arczonalshift": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ARCZonalShift"
+            },
+            "go": {
+              "packageName": "interfacesawsarczonalshift"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.arczonalshift"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_arczonalshift"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_athena": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Athena"
+            },
+            "go": {
+              "packageName": "interfacesawsathena"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.athena"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_athena"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_auditmanager": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AuditManager"
+            },
+            "go": {
+              "packageName": "interfacesawsauditmanager"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.auditmanager"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_auditmanager"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_autoscaling": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AutoScaling"
+            },
+            "go": {
+              "packageName": "interfacesawsautoscaling"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.autoscaling"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_autoscaling"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_autoscalingplans": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.AutoScalingPlans"
+            },
+            "go": {
+              "packageName": "interfacesawsautoscalingplans"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.autoscalingplans"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_autoscalingplans"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_b2bi": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.B2BI"
+            },
+            "go": {
+              "packageName": "interfacesawsb2bi"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.b2bi"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_b2bi"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_backup": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Backup"
+            },
+            "go": {
+              "packageName": "interfacesawsbackup"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.backup"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_backup"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_backupgateway": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.BackupGateway"
+            },
+            "go": {
+              "packageName": "interfacesawsbackupgateway"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.backupgateway"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_backupgateway"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_batch": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Batch"
+            },
+            "go": {
+              "packageName": "interfacesawsbatch"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.batch"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_batch"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_bcmdataexports": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.BCMDataExports"
+            },
+            "go": {
+              "packageName": "interfacesawsbcmdataexports"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.bcmdataexports"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_bcmdataexports"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_bedrock": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Bedrock"
+            },
+            "go": {
+              "packageName": "interfacesawsbedrock"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.bedrock"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_bedrock"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_bedrockagentcore": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.BedrockAgentCore"
+            },
+            "go": {
+              "packageName": "interfacesawsbedrockagentcore"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.bedrockagentcore"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_bedrockagentcore"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_billing": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Billing"
+            },
+            "go": {
+              "packageName": "interfacesawsbilling"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.billing"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_billing"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_billingconductor": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.BillingConductor"
+            },
+            "go": {
+              "packageName": "interfacesawsbillingconductor"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.billingconductor"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_billingconductor"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_budgets": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Budgets"
+            },
+            "go": {
+              "packageName": "interfacesawsbudgets"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.budgets"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_budgets"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_cassandra": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Cassandra"
+            },
+            "go": {
+              "packageName": "interfacesawscassandra"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.cassandra"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_cassandra"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_ce": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CE"
+            },
+            "go": {
+              "packageName": "interfacesawsce"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.ce"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_ce"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_certificatemanager": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CertificateManager"
+            },
+            "go": {
+              "packageName": "interfacesawscertificatemanager"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.certificatemanager"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_certificatemanager"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_chatbot": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Chatbot"
+            },
+            "go": {
+              "packageName": "interfacesawschatbot"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.chatbot"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_chatbot"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_cleanrooms": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CleanRooms"
+            },
+            "go": {
+              "packageName": "interfacesawscleanrooms"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.cleanrooms"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_cleanrooms"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_cleanroomsml": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CleanRoomsML"
+            },
+            "go": {
+              "packageName": "interfacesawscleanroomsml"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.cleanroomsml"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_cleanroomsml"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_cloud9": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Cloud9"
+            },
+            "go": {
+              "packageName": "interfacesawscloud9"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.cloud9"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_cloud9"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_cloudformation": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CloudFormation"
+            },
+            "go": {
+              "packageName": "interfacesawscloudformation"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.cloudformation"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_cloudformation"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_cloudfront": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CloudFront"
+            },
+            "go": {
+              "packageName": "interfacesawscloudfront"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.cloudfront"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_cloudfront"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_cloudtrail": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CloudTrail"
+            },
+            "go": {
+              "packageName": "interfacesawscloudtrail"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.cloudtrail"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_cloudtrail"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_cloudwatch": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CloudWatch"
+            },
+            "go": {
+              "packageName": "interfacesawscloudwatch"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.cloudwatch"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_cloudwatch"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_codeartifact": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CodeArtifact"
+            },
+            "go": {
+              "packageName": "interfacesawscodeartifact"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.codeartifact"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_codeartifact"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_codebuild": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CodeBuild"
+            },
+            "go": {
+              "packageName": "interfacesawscodebuild"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.codebuild"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_codebuild"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_codecommit": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CodeCommit"
+            },
+            "go": {
+              "packageName": "interfacesawscodecommit"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.codecommit"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_codecommit"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_codeconnections": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CodeConnections"
+            },
+            "go": {
+              "packageName": "interfacesawscodeconnections"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.codeconnections"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_codeconnections"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_codedeploy": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CodeDeploy"
+            },
+            "go": {
+              "packageName": "interfacesawscodedeploy"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.codedeploy"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_codedeploy"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_codeguruprofiler": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CodeGuruProfiler"
+            },
+            "go": {
+              "packageName": "interfacesawscodeguruprofiler"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.codeguruprofiler"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_codeguruprofiler"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_codegurureviewer": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CodeGuruReviewer"
+            },
+            "go": {
+              "packageName": "interfacesawscodegurureviewer"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.codegurureviewer"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_codegurureviewer"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_codepipeline": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CodePipeline"
+            },
+            "go": {
+              "packageName": "interfacesawscodepipeline"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.codepipeline"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_codepipeline"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_codestar": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Codestar"
+            },
+            "go": {
+              "packageName": "interfacesawscodestar"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.codestar"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_codestar"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_codestarconnections": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CodeStarConnections"
+            },
+            "go": {
+              "packageName": "interfacesawscodestarconnections"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.codestarconnections"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_codestarconnections"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_codestarnotifications": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CodeStarNotifications"
+            },
+            "go": {
+              "packageName": "interfacesawscodestarnotifications"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.codestarnotifications"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_codestarnotifications"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_cognito": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Cognito"
+            },
+            "go": {
+              "packageName": "interfacesawscognito"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.cognito"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_cognito"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_comprehend": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Comprehend"
+            },
+            "go": {
+              "packageName": "interfacesawscomprehend"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.comprehend"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_comprehend"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_config": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Config"
+            },
+            "go": {
+              "packageName": "interfacesawsconfig"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.config"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_config"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_connect": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Connect"
+            },
+            "go": {
+              "packageName": "interfacesawsconnect"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.connect"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_connect"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_connectcampaigns": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ConnectCampaigns"
+            },
+            "go": {
+              "packageName": "interfacesawsconnectcampaigns"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.connectcampaigns"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_connectcampaigns"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_connectcampaignsv2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ConnectCampaignsV2"
+            },
+            "go": {
+              "packageName": "interfacesawsconnectcampaignsv2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.connectcampaignsv2"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_connectcampaignsv2"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_controltower": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ControlTower"
+            },
+            "go": {
+              "packageName": "interfacesawscontroltower"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.controltower"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_controltower"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_cur": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CUR"
+            },
+            "go": {
+              "packageName": "interfacesawscur"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.cur"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_cur"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_customerprofiles": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.CustomerProfiles"
+            },
+            "go": {
+              "packageName": "interfacesawscustomerprofiles"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.customerprofiles"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_customerprofiles"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_databrew": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.DataBrew"
+            },
+            "go": {
+              "packageName": "interfacesawsdatabrew"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.databrew"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_databrew"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_datapipeline": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.DataPipeline"
+            },
+            "go": {
+              "packageName": "interfacesawsdatapipeline"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.datapipeline"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_datapipeline"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_datasync": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.DataSync"
+            },
+            "go": {
+              "packageName": "interfacesawsdatasync"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.datasync"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_datasync"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_datazone": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.DataZone"
+            },
+            "go": {
+              "packageName": "interfacesawsdatazone"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.datazone"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_datazone"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_dax": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.DAX"
+            },
+            "go": {
+              "packageName": "interfacesawsdax"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.dax"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_dax"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_deadline": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Deadline"
+            },
+            "go": {
+              "packageName": "interfacesawsdeadline"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.deadline"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_deadline"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_detective": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Detective"
+            },
+            "go": {
+              "packageName": "interfacesawsdetective"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.detective"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_detective"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_devicefarm": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.DeviceFarm"
+            },
+            "go": {
+              "packageName": "interfacesawsdevicefarm"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.devicefarm"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_devicefarm"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_devopsagent": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.DevOpsAgent"
+            },
+            "go": {
+              "packageName": "interfacesawsdevopsagent"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.devopsagent"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_devopsagent"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_devopsguru": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.DevOpsGuru"
+            },
+            "go": {
+              "packageName": "interfacesawsdevopsguru"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.devopsguru"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_devopsguru"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_directoryservice": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.DirectoryService"
+            },
+            "go": {
+              "packageName": "interfacesawsdirectoryservice"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.directoryservice"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_directoryservice"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_dlm": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.DLM"
+            },
+            "go": {
+              "packageName": "interfacesawsdlm"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.dlm"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_dlm"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_dms": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.DMS"
+            },
+            "go": {
+              "packageName": "interfacesawsdms"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.dms"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_dms"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_docdb": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.DocDB"
+            },
+            "go": {
+              "packageName": "interfacesawsdocdb"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.docdb"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_docdb"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_docdbelastic": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.DocDBElastic"
+            },
+            "go": {
+              "packageName": "interfacesawsdocdbelastic"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.docdbelastic"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_docdbelastic"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_dsql": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.DSQL"
+            },
+            "go": {
+              "packageName": "interfacesawsdsql"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.dsql"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_dsql"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_dynamodb": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.DynamoDB"
+            },
+            "go": {
+              "packageName": "interfacesawsdynamodb"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.dynamodb"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_dynamodb"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_ec2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.EC2"
+            },
+            "go": {
+              "packageName": "interfacesawsec2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.ec2"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_ec2"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_ecr": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ECR"
+            },
+            "go": {
+              "packageName": "interfacesawsecr"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.ecr"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_ecr"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_ecs": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ECS"
+            },
+            "go": {
+              "packageName": "interfacesawsecs"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.ecs"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_ecs"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_efs": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.EFS"
+            },
+            "go": {
+              "packageName": "interfacesawsefs"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.efs"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_efs"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_eks": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.EKS"
+            },
+            "go": {
+              "packageName": "interfacesawseks"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.eks"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_eks"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_elasticache": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ElastiCache"
+            },
+            "go": {
+              "packageName": "interfacesawselasticache"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.elasticache"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_elasticache"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_elasticbeanstalk": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ElasticBeanstalk"
+            },
+            "go": {
+              "packageName": "interfacesawselasticbeanstalk"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.elasticbeanstalk"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_elasticbeanstalk"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_elasticloadbalancing": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ElasticLoadBalancing"
+            },
+            "go": {
+              "packageName": "interfacesawselasticloadbalancing"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.elasticloadbalancing"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_elasticloadbalancing"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_elasticloadbalancingv2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ElasticLoadBalancingV2"
+            },
+            "go": {
+              "packageName": "interfacesawselasticloadbalancingv2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.elasticloadbalancingv2"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_elasticloadbalancingv2"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_elasticsearch": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Elasticsearch"
+            },
+            "go": {
+              "packageName": "interfacesawselasticsearch"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.elasticsearch"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_elasticsearch"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_emr": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.EMR"
+            },
+            "go": {
+              "packageName": "interfacesawsemr"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.emr"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_emr"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_emrcontainers": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.EMRContainers"
+            },
+            "go": {
+              "packageName": "interfacesawsemrcontainers"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.emrcontainers"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_emrcontainers"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_emrserverless": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.EMRServerless"
+            },
+            "go": {
+              "packageName": "interfacesawsemrserverless"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.emrserverless"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_emrserverless"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_entityresolution": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.EntityResolution"
+            },
+            "go": {
+              "packageName": "interfacesawsentityresolution"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.entityresolution"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_entityresolution"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_events": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Events"
+            },
+            "go": {
+              "packageName": "interfacesawsevents"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.events"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_events"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_eventschemas": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.EventSchemas"
+            },
+            "go": {
+              "packageName": "interfacesawseventschemas"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.eventschemas"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_eventschemas"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_evidently": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Evidently"
+            },
+            "go": {
+              "packageName": "interfacesawsevidently"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.evidently"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_evidently"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_evs": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.EVS"
+            },
+            "go": {
+              "packageName": "interfacesawsevs"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.evs"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_evs"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_finspace": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.FinSpace"
+            },
+            "go": {
+              "packageName": "interfacesawsfinspace"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.finspace"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_finspace"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_fis": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.FIS"
+            },
+            "go": {
+              "packageName": "interfacesawsfis"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.fis"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_fis"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_fms": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.FMS"
+            },
+            "go": {
+              "packageName": "interfacesawsfms"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.fms"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_fms"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_forecast": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Forecast"
+            },
+            "go": {
+              "packageName": "interfacesawsforecast"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.forecast"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_forecast"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_frauddetector": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.FraudDetector"
+            },
+            "go": {
+              "packageName": "interfacesawsfrauddetector"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.frauddetector"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_frauddetector"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_fsx": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.FSx"
+            },
+            "go": {
+              "packageName": "interfacesawsfsx"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.fsx"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_fsx"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_gamelift": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.GameLift"
+            },
+            "go": {
+              "packageName": "interfacesawsgamelift"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.gamelift"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_gamelift"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_gameliftstreams": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.GameLiftStreams"
+            },
+            "go": {
+              "packageName": "interfacesawsgameliftstreams"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.gameliftstreams"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_gameliftstreams"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_globalaccelerator": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.GlobalAccelerator"
+            },
+            "go": {
+              "packageName": "interfacesawsglobalaccelerator"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.globalaccelerator"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_globalaccelerator"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_glue": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Glue"
+            },
+            "go": {
+              "packageName": "interfacesawsglue"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.glue"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_glue"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_grafana": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Grafana"
+            },
+            "go": {
+              "packageName": "interfacesawsgrafana"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.grafana"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_grafana"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_greengrass": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Greengrass"
+            },
+            "go": {
+              "packageName": "interfacesawsgreengrass"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.greengrass"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_greengrass"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_greengrassv2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.GreengrassV2"
+            },
+            "go": {
+              "packageName": "interfacesawsgreengrassv2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.greengrassv2"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_greengrassv2"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_groundstation": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.GroundStation"
+            },
+            "go": {
+              "packageName": "interfacesawsgroundstation"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.groundstation"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_groundstation"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_guardduty": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.GuardDuty"
+            },
+            "go": {
+              "packageName": "interfacesawsguardduty"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.guardduty"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_guardduty"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_healthimaging": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.HealthImaging"
+            },
+            "go": {
+              "packageName": "interfacesawshealthimaging"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.healthimaging"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_healthimaging"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_healthlake": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.HealthLake"
+            },
+            "go": {
+              "packageName": "interfacesawshealthlake"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.healthlake"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_healthlake"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_iam": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.IAM"
+            },
+            "go": {
+              "packageName": "interfacesawsiam"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.iam"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_iam"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_identitystore": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.IdentityStore"
+            },
+            "go": {
+              "packageName": "interfacesawsidentitystore"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.identitystore"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_identitystore"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_imagebuilder": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ImageBuilder"
+            },
+            "go": {
+              "packageName": "interfacesawsimagebuilder"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.imagebuilder"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_imagebuilder"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_inspector": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Inspector"
+            },
+            "go": {
+              "packageName": "interfacesawsinspector"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.inspector"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_inspector"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_inspectorv2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.InspectorV2"
+            },
+            "go": {
+              "packageName": "interfacesawsinspectorv2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.inspectorv2"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_inspectorv2"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_internetmonitor": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.InternetMonitor"
+            },
+            "go": {
+              "packageName": "interfacesawsinternetmonitor"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.internetmonitor"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_internetmonitor"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_invoicing": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Invoicing"
+            },
+            "go": {
+              "packageName": "interfacesawsinvoicing"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.invoicing"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_invoicing"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_iot": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.IoT"
+            },
+            "go": {
+              "packageName": "interfacesawsiot"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.iot"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_iot"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_iotanalytics": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.IoTAnalytics"
+            },
+            "go": {
+              "packageName": "interfacesawsiotanalytics"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.iotanalytics"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_iotanalytics"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_iotcoredeviceadvisor": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.IoTCoreDeviceAdvisor"
+            },
+            "go": {
+              "packageName": "interfacesawsiotcoredeviceadvisor"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.iotcoredeviceadvisor"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_iotcoredeviceadvisor"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_iotevents": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.IoTEvents"
+            },
+            "go": {
+              "packageName": "interfacesawsiotevents"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.iotevents"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_iotevents"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_iotfleethub": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.IoTFleetHub"
+            },
+            "go": {
+              "packageName": "interfacesawsiotfleethub"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.iotfleethub"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_iotfleethub"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_iotfleetwise": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.IoTFleetWise"
+            },
+            "go": {
+              "packageName": "interfacesawsiotfleetwise"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.iotfleetwise"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_iotfleetwise"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_iotsitewise": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.IoTSiteWise"
+            },
+            "go": {
+              "packageName": "interfacesawsiotsitewise"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.iotsitewise"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_iotsitewise"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_iotthingsgraph": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.IoTThingsGraph"
+            },
+            "go": {
+              "packageName": "interfacesawsiotthingsgraph"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.iotthingsgraph"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_iotthingsgraph"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_iottwinmaker": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.IoTTwinMaker"
+            },
+            "go": {
+              "packageName": "interfacesawsiottwinmaker"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.iottwinmaker"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_iottwinmaker"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_iotwireless": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.IoTWireless"
+            },
+            "go": {
+              "packageName": "interfacesawsiotwireless"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.iotwireless"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_iotwireless"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_ivs": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Ivs"
+            },
+            "go": {
+              "packageName": "interfacesawsivs"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.ivs"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_ivs"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_ivschat": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.IVSChat"
+            },
+            "go": {
+              "packageName": "interfacesawsivschat"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.ivschat"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_ivschat"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_kafkaconnect": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.KafkaConnect"
+            },
+            "go": {
+              "packageName": "interfacesawskafkaconnect"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.kafkaconnect"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_kafkaconnect"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_kendra": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Kendra"
+            },
+            "go": {
+              "packageName": "interfacesawskendra"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.kendra"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_kendra"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_kendraranking": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.KendraRanking"
+            },
+            "go": {
+              "packageName": "interfacesawskendraranking"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.kendraranking"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_kendraranking"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_kinesis": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Kinesis"
+            },
+            "go": {
+              "packageName": "interfacesawskinesis"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.kinesis"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_kinesis"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_kinesisanalytics": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.KinesisAnalytics"
+            },
+            "go": {
+              "packageName": "interfacesawskinesisanalytics"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.kinesisanalytics"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_kinesisanalytics"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_kinesisanalyticsv2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.KinesisAnalyticsV2"
+            },
+            "go": {
+              "packageName": "interfacesawskinesisanalyticsv2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.kinesisanalyticsv2"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_kinesisanalyticsv2"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_kinesisfirehose": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.KinesisFirehose"
+            },
+            "go": {
+              "packageName": "interfacesawskinesisfirehose"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.kinesisfirehose"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_kinesisfirehose"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_kinesisvideo": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.KinesisVideo"
+            },
+            "go": {
+              "packageName": "interfacesawskinesisvideo"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.kinesisvideo"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_kinesisvideo"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_kms": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.KMS"
+            },
+            "go": {
+              "packageName": "interfacesawskms"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.kms"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_kms"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_lakeformation": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.LakeFormation"
+            },
+            "go": {
+              "packageName": "interfacesawslakeformation"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.lakeformation"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_lakeformation"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_lambda": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Lambda"
+            },
+            "go": {
+              "packageName": "interfacesawslambda"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.lambda"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_lambda"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_launchwizard": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.LaunchWizard"
+            },
+            "go": {
+              "packageName": "interfacesawslaunchwizard"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.launchwizard"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_launchwizard"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_lex": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Lex"
+            },
+            "go": {
+              "packageName": "interfacesawslex"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.lex"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_lex"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_licensemanager": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.LicenseManager"
+            },
+            "go": {
+              "packageName": "interfacesawslicensemanager"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.licensemanager"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_licensemanager"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_lightsail": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Lightsail"
+            },
+            "go": {
+              "packageName": "interfacesawslightsail"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.lightsail"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_lightsail"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_location": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Location"
+            },
+            "go": {
+              "packageName": "interfacesawslocation"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.location"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_location"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_logs": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Logs"
+            },
+            "go": {
+              "packageName": "interfacesawslogs"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.logs"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_logs"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_lookoutequipment": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.LookoutEquipment"
+            },
+            "go": {
+              "packageName": "interfacesawslookoutequipment"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.lookoutequipment"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_lookoutequipment"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_lookoutmetrics": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.LookoutMetrics"
+            },
+            "go": {
+              "packageName": "interfacesawslookoutmetrics"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.lookoutmetrics"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_lookoutmetrics"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_lookoutvision": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.LookoutVision"
+            },
+            "go": {
+              "packageName": "interfacesawslookoutvision"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.lookoutvision"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_lookoutvision"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_m2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.M2"
+            },
+            "go": {
+              "packageName": "interfacesawsm2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.m2"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_m2"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_macie": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Macie"
+            },
+            "go": {
+              "packageName": "interfacesawsmacie"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.macie"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_macie"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_managedblockchain": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ManagedBlockchain"
+            },
+            "go": {
+              "packageName": "interfacesawsmanagedblockchain"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.managedblockchain"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_managedblockchain"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_mediaconnect": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.MediaConnect"
+            },
+            "go": {
+              "packageName": "interfacesawsmediaconnect"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.mediaconnect"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_mediaconnect"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_mediaconvert": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.MediaConvert"
+            },
+            "go": {
+              "packageName": "interfacesawsmediaconvert"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.mediaconvert"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_mediaconvert"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_medialive": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.MediaLive"
+            },
+            "go": {
+              "packageName": "interfacesawsmedialive"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.medialive"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_medialive"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_mediapackage": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.MediaPackage"
+            },
+            "go": {
+              "packageName": "interfacesawsmediapackage"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.mediapackage"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_mediapackage"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_mediapackagev2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.MediaPackageV2"
+            },
+            "go": {
+              "packageName": "interfacesawsmediapackagev2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.mediapackagev2"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_mediapackagev2"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_mediastore": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.MediaStore"
+            },
+            "go": {
+              "packageName": "interfacesawsmediastore"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.mediastore"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_mediastore"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_mediatailor": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.MediaTailor"
+            },
+            "go": {
+              "packageName": "interfacesawsmediatailor"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.mediatailor"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_mediatailor"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_memorydb": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.MemoryDB"
+            },
+            "go": {
+              "packageName": "interfacesawsmemorydb"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.memorydb"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_memorydb"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_mpa": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.MPA"
+            },
+            "go": {
+              "packageName": "interfacesawsmpa"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.mpa"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_mpa"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_msk": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.MSK"
+            },
+            "go": {
+              "packageName": "interfacesawsmsk"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.msk"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_msk"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_mwaa": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.MWAA"
+            },
+            "go": {
+              "packageName": "interfacesawsmwaa"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.mwaa"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_mwaa"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_neptune": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Neptune"
+            },
+            "go": {
+              "packageName": "interfacesawsneptune"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.neptune"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_neptune"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_neptunegraph": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.NeptuneGraph"
+            },
+            "go": {
+              "packageName": "interfacesawsneptunegraph"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.neptunegraph"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_neptunegraph"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_networkfirewall": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.NetworkFirewall"
+            },
+            "go": {
+              "packageName": "interfacesawsnetworkfirewall"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.networkfirewall"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_networkfirewall"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_networkmanager": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.NetworkManager"
+            },
+            "go": {
+              "packageName": "interfacesawsnetworkmanager"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.networkmanager"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_networkmanager"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_nimblestudio": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.NimbleStudio"
+            },
+            "go": {
+              "packageName": "interfacesawsnimblestudio"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.nimblestudio"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_nimblestudio"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_notifications": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Notifications"
+            },
+            "go": {
+              "packageName": "interfacesawsnotifications"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.notifications"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_notifications"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_notificationscontacts": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.NotificationsContacts"
+            },
+            "go": {
+              "packageName": "interfacesawsnotificationscontacts"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.notificationscontacts"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_notificationscontacts"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_oam": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Oam"
+            },
+            "go": {
+              "packageName": "interfacesawsoam"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.oam"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_oam"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_observabilityadmin": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ObservabilityAdmin"
+            },
+            "go": {
+              "packageName": "interfacesawsobservabilityadmin"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.observabilityadmin"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_observabilityadmin"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_odb": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ODB"
+            },
+            "go": {
+              "packageName": "interfacesawsodb"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.odb"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_odb"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_omics": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Omics"
+            },
+            "go": {
+              "packageName": "interfacesawsomics"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.omics"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_omics"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_opensearchserverless": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.OpenSearchServerless"
+            },
+            "go": {
+              "packageName": "interfacesawsopensearchserverless"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.opensearchserverless"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_opensearchserverless"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_opensearchservice": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.OpenSearchService"
+            },
+            "go": {
+              "packageName": "interfacesawsopensearchservice"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.opensearchservice"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_opensearchservice"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_opsworks": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.OpsWorks"
+            },
+            "go": {
+              "packageName": "interfacesawsopsworks"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.opsworks"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_opsworks"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_opsworkscm": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.OpsWorksCM"
+            },
+            "go": {
+              "packageName": "interfacesawsopsworkscm"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.opsworkscm"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_opsworkscm"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_organizations": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Organizations"
+            },
+            "go": {
+              "packageName": "interfacesawsorganizations"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.organizations"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_organizations"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_osis": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.OSIS"
+            },
+            "go": {
+              "packageName": "interfacesawsosis"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.osis"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_osis"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_panorama": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Panorama"
+            },
+            "go": {
+              "packageName": "interfacesawspanorama"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.panorama"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_panorama"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_paymentcryptography": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.PaymentCryptography"
+            },
+            "go": {
+              "packageName": "interfacesawspaymentcryptography"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.paymentcryptography"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_paymentcryptography"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_pcaconnectorad": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.PCAConnectorAD"
+            },
+            "go": {
+              "packageName": "interfacesawspcaconnectorad"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.pcaconnectorad"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_pcaconnectorad"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_pcaconnectorscep": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.PCAConnectorSCEP"
+            },
+            "go": {
+              "packageName": "interfacesawspcaconnectorscep"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.pcaconnectorscep"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_pcaconnectorscep"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_pcs": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.PCS"
+            },
+            "go": {
+              "packageName": "interfacesawspcs"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.pcs"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_pcs"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_personalize": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Personalize"
+            },
+            "go": {
+              "packageName": "interfacesawspersonalize"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.personalize"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_personalize"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_pinpoint": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Pinpoint"
+            },
+            "go": {
+              "packageName": "interfacesawspinpoint"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.pinpoint"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_pinpoint"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_pinpointemail": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.PinpointEmail"
+            },
+            "go": {
+              "packageName": "interfacesawspinpointemail"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.pinpointemail"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_pinpointemail"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_pipes": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Pipes"
+            },
+            "go": {
+              "packageName": "interfacesawspipes"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.pipes"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_pipes"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_proton": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Proton"
+            },
+            "go": {
+              "packageName": "interfacesawsproton"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.proton"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_proton"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_qbusiness": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.QBusiness"
+            },
+            "go": {
+              "packageName": "interfacesawsqbusiness"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.qbusiness"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_qbusiness"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_qldb": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.QLDB"
+            },
+            "go": {
+              "packageName": "interfacesawsqldb"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.qldb"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_qldb"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_quicksight": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.QuickSight"
+            },
+            "go": {
+              "packageName": "interfacesawsquicksight"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.quicksight"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_quicksight"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_ram": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.RAM"
+            },
+            "go": {
+              "packageName": "interfacesawsram"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.ram"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_ram"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_rbin": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Rbin"
+            },
+            "go": {
+              "packageName": "interfacesawsrbin"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.rbin"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_rbin"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_rds": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.RDS"
+            },
+            "go": {
+              "packageName": "interfacesawsrds"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.rds"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_rds"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_redshift": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Redshift"
+            },
+            "go": {
+              "packageName": "interfacesawsredshift"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.redshift"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_redshift"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_redshiftserverless": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.RedshiftServerless"
+            },
+            "go": {
+              "packageName": "interfacesawsredshiftserverless"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.redshiftserverless"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_redshiftserverless"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_refactorspaces": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.RefactorSpaces"
+            },
+            "go": {
+              "packageName": "interfacesawsrefactorspaces"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.refactorspaces"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_refactorspaces"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_rekognition": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Rekognition"
+            },
+            "go": {
+              "packageName": "interfacesawsrekognition"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.rekognition"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_rekognition"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_resiliencehub": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ResilienceHub"
+            },
+            "go": {
+              "packageName": "interfacesawsresiliencehub"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.resiliencehub"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_resiliencehub"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_resourceexplorer2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ResourceExplorer2"
+            },
+            "go": {
+              "packageName": "interfacesawsresourceexplorer2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.resourceexplorer2"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_resourceexplorer2"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_resourcegroups": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ResourceGroups"
+            },
+            "go": {
+              "packageName": "interfacesawsresourcegroups"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.resourcegroups"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_resourcegroups"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_robomaker": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.RoboMaker"
+            },
+            "go": {
+              "packageName": "interfacesawsrobomaker"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.robomaker"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_robomaker"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_rolesanywhere": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.RolesAnywhere"
+            },
+            "go": {
+              "packageName": "interfacesawsrolesanywhere"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.rolesanywhere"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_rolesanywhere"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_route53": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Route53"
+            },
+            "go": {
+              "packageName": "interfacesawsroute53"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.route53"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_route53"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_route53profiles": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Route53Profiles"
+            },
+            "go": {
+              "packageName": "interfacesawsroute53profiles"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.route53profiles"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_route53profiles"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_route53recoverycontrol": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Route53RecoveryControl"
+            },
+            "go": {
+              "packageName": "interfacesawsroute53recoverycontrol"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.route53recoverycontrol"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_route53recoverycontrol"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_route53recoveryreadiness": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Route53RecoveryReadiness"
+            },
+            "go": {
+              "packageName": "interfacesawsroute53recoveryreadiness"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.route53recoveryreadiness"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_route53recoveryreadiness"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_route53resolver": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Route53Resolver"
+            },
+            "go": {
+              "packageName": "interfacesawsroute53resolver"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.route53resolver"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_route53resolver"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_rtbfabric": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.RTBFabric"
+            },
+            "go": {
+              "packageName": "interfacesawsrtbfabric"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.rtbfabric"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_rtbfabric"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_rum": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.RUM"
+            },
+            "go": {
+              "packageName": "interfacesawsrum"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.rum"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_rum"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_s3": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.S3"
+            },
+            "go": {
+              "packageName": "interfacesawss3"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.s3"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_s3"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_s3express": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.S3Express"
+            },
+            "go": {
+              "packageName": "interfacesawss3express"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.s3express"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_s3express"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_s3objectlambda": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.S3ObjectLambda"
+            },
+            "go": {
+              "packageName": "interfacesawss3objectlambda"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.s3objectlambda"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_s3objectlambda"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_s3outposts": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.S3Outposts"
+            },
+            "go": {
+              "packageName": "interfacesawss3outposts"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.s3outposts"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_s3outposts"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_s3tables": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.S3Tables"
+            },
+            "go": {
+              "packageName": "interfacesawss3tables"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.s3tables"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_s3tables"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_s3vectors": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.S3Vectors"
+            },
+            "go": {
+              "packageName": "interfacesawss3vectors"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.s3vectors"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_s3vectors"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_sagemaker": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Sagemaker"
+            },
+            "go": {
+              "packageName": "interfacesawssagemaker"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.sagemaker"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_sagemaker"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_sam": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SAM"
+            },
+            "go": {
+              "packageName": "interfacesawssam"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.sam"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_sam"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_scheduler": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Scheduler"
+            },
+            "go": {
+              "packageName": "interfacesawsscheduler"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.scheduler"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_scheduler"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_sdb": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SDB"
+            },
+            "go": {
+              "packageName": "interfacesawssdb"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.sdb"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_sdb"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_secretsmanager": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SecretsManager"
+            },
+            "go": {
+              "packageName": "interfacesawssecretsmanager"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.secretsmanager"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_secretsmanager"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_securityhub": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SecurityHub"
+            },
+            "go": {
+              "packageName": "interfacesawssecurityhub"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.securityhub"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_securityhub"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_securitylake": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SecurityLake"
+            },
+            "go": {
+              "packageName": "interfacesawssecuritylake"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.securitylake"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_securitylake"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_servicecatalog": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Servicecatalog"
+            },
+            "go": {
+              "packageName": "interfacesawsservicecatalog"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.servicecatalog"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_servicecatalog"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_servicecatalogappregistry": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Servicecatalogappregistry"
+            },
+            "go": {
+              "packageName": "interfacesawsservicecatalogappregistry"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.servicecatalogappregistry"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_servicecatalogappregistry"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_servicediscovery": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.ServiceDiscovery"
+            },
+            "go": {
+              "packageName": "interfacesawsservicediscovery"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.servicediscovery"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_servicediscovery"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_ses": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SES"
+            },
+            "go": {
+              "packageName": "interfacesawsses"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.ses"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_ses"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_shield": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Shield"
+            },
+            "go": {
+              "packageName": "interfacesawsshield"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.shield"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_shield"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_signer": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Signer"
+            },
+            "go": {
+              "packageName": "interfacesawssigner"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.signer"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_signer"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_simspaceweaver": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SimSpaceWeaver"
+            },
+            "go": {
+              "packageName": "interfacesawssimspaceweaver"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.simspaceweaver"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_simspaceweaver"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_smsvoice": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SMSVOICE"
+            },
+            "go": {
+              "packageName": "interfacesawssmsvoice"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.smsvoice"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_smsvoice"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_sns": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SNS"
+            },
+            "go": {
+              "packageName": "interfacesawssns"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.sns"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_sns"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_sqs": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SQS"
+            },
+            "go": {
+              "packageName": "interfacesawssqs"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.sqs"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_sqs"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_ssm": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SSM"
+            },
+            "go": {
+              "packageName": "interfacesawsssm"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.ssm"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_ssm"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_ssmcontacts": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SSMContacts"
+            },
+            "go": {
+              "packageName": "interfacesawsssmcontacts"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.ssmcontacts"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_ssmcontacts"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_ssmguiconnect": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SSMGuiConnect"
+            },
+            "go": {
+              "packageName": "interfacesawsssmguiconnect"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.ssmguiconnect"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_ssmguiconnect"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_ssmincidents": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SSMIncidents"
+            },
+            "go": {
+              "packageName": "interfacesawsssmincidents"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.ssmincidents"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_ssmincidents"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_ssmquicksetup": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SSMQuickSetup"
+            },
+            "go": {
+              "packageName": "interfacesawsssmquicksetup"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.ssmquicksetup"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_ssmquicksetup"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_sso": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SSO"
+            },
+            "go": {
+              "packageName": "interfacesawssso"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.sso"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_sso"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_stepfunctions": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.StepFunctions"
+            },
+            "go": {
+              "packageName": "interfacesawsstepfunctions"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.stepfunctions"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_stepfunctions"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_supportapp": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SupportApp"
+            },
+            "go": {
+              "packageName": "interfacesawssupportapp"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.supportapp"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_supportapp"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_synthetics": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Synthetics"
+            },
+            "go": {
+              "packageName": "interfacesawssynthetics"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.synthetics"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_synthetics"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_systemsmanagersap": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.SystemsManagerSAP"
+            },
+            "go": {
+              "packageName": "interfacesawssystemsmanagersap"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.systemsmanagersap"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_systemsmanagersap"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_timestream": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Timestream"
+            },
+            "go": {
+              "packageName": "interfacesawstimestream"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.timestream"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_timestream"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_transfer": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Transfer"
+            },
+            "go": {
+              "packageName": "interfacesawstransfer"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.transfer"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_transfer"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_verifiedpermissions": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.VerifiedPermissions"
+            },
+            "go": {
+              "packageName": "interfacesawsverifiedpermissions"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.verifiedpermissions"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_verifiedpermissions"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_voiceid": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.VoiceID"
+            },
+            "go": {
+              "packageName": "interfacesawsvoiceid"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.voiceid"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_voiceid"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_vpclattice": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.VpcLattice"
+            },
+            "go": {
+              "packageName": "interfacesawsvpclattice"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.vpclattice"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_vpclattice"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_waf": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.WAF"
+            },
+            "go": {
+              "packageName": "interfacesawswaf"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.waf"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_waf"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_wafregional": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.WAFRegional"
+            },
+            "go": {
+              "packageName": "interfacesawswafregional"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.regional"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_wafregional"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_wafv2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.WAFv2"
+            },
+            "go": {
+              "packageName": "interfacesawswafv2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.wafv2"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_wafv2"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_wisdom": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.Wisdom"
+            },
+            "go": {
+              "packageName": "interfacesawswisdom"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.wisdom"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_wisdom"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_workspaces": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.WorkSpaces"
+            },
+            "go": {
+              "packageName": "interfacesawsworkspaces"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.workspaces"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_workspaces"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_workspacesinstances": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.WorkspacesInstances"
+            },
+            "go": {
+              "packageName": "interfacesawsworkspacesinstances"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.workspacesinstances"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_workspacesinstances"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_workspacesthinclient": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.WorkSpacesThinClient"
+            },
+            "go": {
+              "packageName": "interfacesawsworkspacesthinclient"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.workspacesthinclient"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_workspacesthinclient"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_workspacesweb": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.WorkSpacesWeb"
+            },
+            "go": {
+              "packageName": "interfacesawsworkspacesweb"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.workspacesweb"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_workspacesweb"
+            }
+          }
+        },
+        "aws-cdk-lib.interfaces.aws_xray": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Interfaces.XRay"
+            },
+            "go": {
+              "packageName": "interfacesawsxray"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.interfaces.xray"
+            },
+            "python": {
+              "module": "aws_cdk.interfaces.aws_xray"
             }
           }
         },
@@ -3984,7 +8473,7 @@
   },
   "name": "@cxbuilder/flow-config",
   "readme": {
-    "markdown": "# @cxbuilder/flow-config\n\n[![CI/CD Pipeline](https://github.com/cxbuilder/flow-config/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/cxbuilder/flow-config/actions/workflows/ci-cd.yml)\n[![npm version](https://badge.fury.io/js/@cxbuilder%2Fflow-config.svg)](https://badge.fury.io/js/@cxbuilder%2Fflow-config)\n[![PyPI version](https://badge.fury.io/py/cxbuilder-flow-config.svg)](https://badge.fury.io/py/cxbuilder-flow-config)\n[![View on Construct Hub](https://constructs.dev/badge?package=%40cxbuilder%2Fflow-config)](https://constructs.dev/packages/@cxbuilder/flow-config)\n\nAWS CDK constructs for Amazon Connect FlowConfig - a third-party app for configuring variables and prompts in Connect contact flows.\n\n## Links\n\n- [Screenshots](./docs/screenshots/)\n- [Architecture](./docs/Architecture.md)\n- [DataModel](./docs/DataModel.md)\n\n## Installation\n\n```bash\nnpm install @cxbuilder/flow-config\n```\n\n## Usage\n\n### Standard Deployment (Public)\n\n```typescript\nimport { FlowConfigStack } from '@cxbuilder/flow-config';\nimport * as cdk from 'aws-cdk-lib';\n\nconst app = new cdk.App();\nnew FlowConfigStack(app, 'FlowConfigStack', {\n  prefix: 'my-flow-config',\n  env: {\n    region: 'us-east-1',\n    account: 'YOUR_ACCOUNT_ID',\n  },\n  cognito: {\n    domain: 'https://your-auth-domain.com',\n    userPoolId: 'us-east-1_YourPoolId',\n  },\n  connectInstanceArn:\n    'arn:aws:connect:us-east-1:YOUR_ACCOUNT:instance/YOUR_INSTANCE_ID',\n  alertEmails: ['admin@yourcompany.com'],\n});\n```\n\n### VPC Private Deployment\n\nFor enhanced security, you can deploy the application to run entirely within a VPC with private endpoints:\n\n```typescript\nimport { FlowConfigStack, VpcConfig } from '@cxbuilder/flow-config';\nimport * as cdk from 'aws-cdk-lib';\n\nconst app = new cdk.App();\n\n// Configure VPC using string IDs - the stack will resolve these to CDK objects\nconst vpcConfig: VpcConfig = {\n  vpcId: 'vpc-12345678',\n  lambdaSecurityGroupIds: ['sg-lambda123'],\n  privateSubnetIds: ['subnet-12345', 'subnet-67890'],\n  vpcEndpointSecurityGroupIds: ['sg-endpoint123'],\n};\n\nnew FlowConfigStack(app, 'FlowConfigStack', {\n  prefix: 'my-flow-config',\n  env: {\n    region: 'us-east-1',\n    account: 'YOUR_ACCOUNT_ID',\n  },\n  cognito: {\n    domain: 'https://your-auth-domain.com',\n    userPoolId: 'us-east-1_YourPoolId',\n  },\n  connectInstanceArn:\n    'arn:aws:connect:us-east-1:YOUR_ACCOUNT:instance/YOUR_INSTANCE_ID',\n  alertEmails: ['admin@yourcompany.com'],\n  vpc: vpcConfig, // Enable VPC private deployment\n});\n```\n\n### Multi-Region Global Table Deployment\n\nFor global resilience, deploy the application across multiple regions with DynamoDB Global Tables:\n\n#### Primary Region Setup\n\n```typescript\nimport { FlowConfigStack, GlobalTableConfig } from '@cxbuilder/flow-config';\nimport * as cdk from 'aws-cdk-lib';\n\nconst app = new cdk.App();\n\n// Primary region creates the global table with replicas\nconst primaryGlobalTable: GlobalTableConfig = {\n  isPrimaryRegion: true,\n  replicaRegions: ['us-west-2', 'eu-west-1'],\n};\n\nnew FlowConfigStack(app, 'FlowConfigStack-Primary', {\n  prefix: 'my-flow-config',\n  env: {\n    region: 'us-east-1',\n    account: 'YOUR_ACCOUNT_ID',\n  },\n  cognito: {\n    domain: 'https://your-auth-domain.com',\n    userPoolId: 'us-east-1_YourPoolId',\n  },\n  connectInstanceArn:\n    'arn:aws:connect:us-east-1:YOUR_ACCOUNT:instance/YOUR_INSTANCE_ID',\n  alertEmails: ['admin@yourcompany.com'],\n  globalTable: primaryGlobalTable, // Enable global table\n});\n```\n\n#### Secondary Region Setup\n\n```typescript\nnew FlowConfigStack(app, 'FlowConfigStack-Secondary', {\n  prefix: 'my-flow-config',\n  env: {\n    region: 'us-west-2',\n    account: 'YOUR_ACCOUNT_ID',\n  },\n  cognito: {\n    domain: 'https://your-auth-domain.com',\n    userPoolId: 'us-west-2_YourPoolId',\n  },\n  connectInstanceArn:\n    'arn:aws:connect:us-west-2:YOUR_ACCOUNT:instance/YOUR_INSTANCE_ID',\n  alertEmails: ['admin@yourcompany.com'],\n  globalTable: {\n    isPrimaryRegion: false, // Reference global table\n  },\n});\n```\n\n## Features\n\n- **Serverless Architecture**: Built with AWS Lambda, DynamoDB, and API Gateway\n- **Amazon Connect Integration**: GetConfig Lambda function integrated directly with Connect contact flows\n- **Third-Party App**: Web-based interface embedded in Amazon Connect Agent Workspace\n- **Multi-Language Support**: Configure prompts for different languages and channels (voice/chat)\n- **Real-time Preview**: Text-to-speech preview using Amazon Polly\n- **Secure Access**: Integration with Amazon Connect and AWS Verified Permissions\n- **Flexible Deployment Options**:\n  - **Single-Region**: Standard deployment with regional DynamoDB table\n  - **Multi-Region**: Global table support with automatic replication across regions\n  - **Public Deployment**: Standard internet-accessible API Gateway and Lambda functions\n  - **VPC Private Deployment**: Private API Gateway endpoints, VPC-enabled Lambda functions, and VPC endpoints for enhanced security\n\n## GetConfig Lambda Integration\n\nThe GetConfig Lambda function is used within contact flows to access your flow configs. This function is automatically integrated with your Amazon Connect instance during deployment.\n\n### Contact Flow Event Structure\n\nThe Lambda function handles Amazon Connect Contact Flow events with the following structure:\n\n```json\n{\n  \"Details\": {\n    \"Parameters\": {\n      \"id\": \"main-queue\",\n      \"lang\": \"es-US\"\n    },\n    \"ContactData\": {\n      \"Channel\": \"VOICE\",\n      \"LanguageCode\": \"en-US\"\n    }\n  }\n}\n```\n\n### Input Parameters and Priority\n\n1. **Required Parameters**:\n\n   - **`id`**: Flow configuration identifier (always required)\n     - Provided via `Details.Parameters.id`\n\n2. **Optional Language Selection** (in order of precedence):\n\n   - `Details.Parameters.lang` (highest priority)\n   - `Details.ContactData.LanguageCode`\n   - Defaults to `\"en-US\"`\n\n3. **Channel Detection**:\n   - Automatically read from `Details.ContactData.Channel`\n   - Supports `\"VOICE\"` and `\"CHAT\"`\n   - Defaults to `\"voice\"`\n\n### Alternative Input Format (Testing)\n\nFor direct testing or non-Connect invocation:\n\n```json\n{\n  \"id\": \"main-queue\",\n  \"lang\": \"es-US\",\n  \"channel\": \"voice\"\n}\n```\n\n### Function Behavior\n\n1. **Parameter Resolution**:\n\n   - Extracts `id` from Connect event parameters (required)\n   - Resolves language from parameters → attributes → default\n   - Determines channel from Contact Flow event data\n\n2. **Processing Steps**:\n\n   - Retrieves the flow config from DynamoDB using the provided ID\n   - Includes all variables from the flow config in the result\n   - For each prompt in the flow config:\n     - Selects the appropriate language version\n     - Uses voice content by default\n     - For chat channel:\n       - Uses chat-specific content if available\n       - Strips SSML tags from voice content if no chat content exists\n\n3. **Output**:\n   - Returns a flattened object containing:\n     - All variable key-value pairs from the flow config\n     - All prompt values resolved for the specified language and channel\n\n### Setting Up in Contact Flow\n\n1. **Add \"Invoke AWS Lambda function\" block** to your contact flow\n2. **Select the GetConfig Lambda function** (deployed as `${prefix}`)\n3. **Configure parameters**:\n\n```json\n{\n  \"id\": \"main-queue\"\n}\n```\n\nOr with explicit language:\n\n```json\n{\n  \"id\": \"main-queue\",\n  \"lang\": \"es-US\"\n}\n```\n\n### Using Returned Data\n\nThe Lambda response is automatically available in subsequent blocks:\n\n- **Set contact attributes**: Use `$.External.variableName`\n- **Play prompt**: Use `$.External.promptName`\n- **Check contact attributes**: Reference returned variables for routing decisions\n\n### Example Contact Flow Integration\n\n```\n[Get customer input] → [Invoke Lambda: GetConfig]\n                           ↓\n                      [Set contact attributes]\n                           ↓\n                      [Play prompt: $.External.welcomeMessage]\n                           ↓\n                      [Route based on: $.External.routingMode]\n```\n\n### Size Considerations\n\n- Amazon Connect has a Lambda response size limit of 32KB\n- The combined size of returned variables and prompts should be less than this limit\n- For large flow configs with many prompts or languages, consider implementing pagination or selective loading\n\n### Logger\n\n[Lambda PowerTools Logger](https://docs.powertools.aws.dev/lambda/typescript/latest/core/logger/) provides a lightweight logger implementation with JSON output.\n\nTips:\n\n- Use the `appendKeys()` method to add `ContactId` to your connect log lambda output.\n\n### Open API Spec\n\nThis template defines an Open API Spec for the API GW Lambdas. This allows use to generate a TypeScript api client to be used by the frontend app. We can also generate a API client in any language from the same spec to allow the client to better integrate with our apps.\n\n- [constructs/aws-openapigateway-lambda](https://docs.aws.amazon.com/solutions/latest/constructs/aws-openapigateway-lambda.html)\n- [OpenAPI Editor](https://marketplace.visualstudio.com/items?itemName=42Crunch.vscode-openapi)\n- [OpenApy TypeScript Generator](https://openapi-ts.pages.dev/introduction)\n\n## Development\n\n### Frontend Development\n\nThe frontend React application integrates with Amazon Connect Agent Workspace using the Connect SDK:\n\n```bash\n# Start local development server\nnpm start\n\n# Build for production\nnpm run build\n```\n\nFor local development, point your Amazon Connect third-party app configuration to `localhost:3000`. The application requires execution within Agent Workspace for Connect SDK functionality.\n\n### Lambda Development\n\nLambda functions are bundled automatically during the build process:\n\n```bash\n# Bundle Lambda functions\nnpm run build:lambdas\n\n# Full build (CDK + Frontend + Lambdas)\nnpm run build\n```\n"
+    "markdown": "# FlowConfig for Amazon Connect\n\n[![CI/CD Pipeline](https://github.com/cxbuilder/flow-config/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/cxbuilder/flow-config/actions/workflows/ci-cd.yml)\n[![npm version](https://badge.fury.io/js/@cxbuilder%2Fflow-config.svg)](https://badge.fury.io/js/@cxbuilder%2Fflow-config)\n[![PyPI version](https://badge.fury.io/py/cxbuilder-flow-config.svg)](https://badge.fury.io/py/cxbuilder-flow-config)\n[![View on Construct Hub](https://constructs.dev/badge?package=%40cxbuilder%2Fflow-config)](https://constructs.dev/packages/@cxbuilder/flow-config)\n\n**Empower your business users to manage Amazon Connect contact flow configurations without IT involvement.**\n\nFlowConfig is a third-party app for Amazon Connect that lets business users update customer messages, queue settings, and routing variables in real-time—without touching contact flows or deploying code.\n\n![FlowConfig Admin View](./docs/screenshots/landing-admin.png)\n\n## The Problem\n\nYour contact center needs to respond quickly to changing conditions:\n\n- 🚨 **Emergency closures** require immediate routing changes\n- 🗓️ **Seasonal hours** need frequent prompt updates\n- 🌍 **Multi-language support** means managing dozens of message variants\n- 🏢 **Multiple locations** each need custom greetings and settings\n- ⏱️ **Queue thresholds** must adapt to call volume fluctuations\n\nBut every change requires:\n- Opening Amazon Connect contact flow designer\n- Finding and updating multiple text blocks\n- Testing changes\n- Deploying updates\n- Waiting for IT availability\n\n**There has to be a better way.**\n\n## The Solution\n\nFlowConfig separates **configuration** from **logic**. Your contact flow designers build reusable flows once, and business users manage the values that drive them.\n\n### What You Can Configure\n\n**Variables** - Settings that control contact flow behavior:\n- Boolean flags: `closure`, `offerCallback`, `holidayMode`\n- Numbers: `maxWaitTime`, `queueDepth`, `transferTimeout`\n- Text values: `skillLevel`, `routingMode`, `priority`\n\n**Prompts** - Customer-facing messages:\n- Multi-language support (English, Spanish, French, etc.)\n- Separate voice and chat content\n- Text-to-speech preview before going live\n\n### Who Uses FlowConfig\n\n**👔 Edit Users**\n- Update all variables and prompts across all flow configurations\n- Change settings during high-volume events or emergencies\n- Update prompts for holidays, closures, and special events\n- Preview voice messages before customers hear them\n- Make changes instantly without IT involvement\n\n**🔧 Administrators (Admin Access)**\n- Create and organize flow configurations\n- Define variable schema types (Text, Number, Boolean, Select)\n- Add/remove variables and prompts\n- Set up multi-language prompts for global operations\n- Import/export configurations across environments\n- Configure application settings (available locales and voices)\n\n**👀 Read-Only Users**\n- View all configurations and settings\n- Monitor what messages customers are currently hearing\n- Review variable values without editing capability\n\n## Quick Links\n\n### 📘 I'm a Business User\n- [Edit User Guide](./docs/UserGuide-Edit.md) - Learn how to update variables and prompts\n- [Administrator Guide](./docs/UserGuide-Admin.md) - Create and manage configurations\n- [Read-Only User Guide](./docs/UserGuide-Read.md) - View configurations\n\n### 🛠️ I'm a Developer/Architect\n- [Installation & Deployment](./docs/Installation.md) - Get started deploying FlowConfig\n- [Architecture](./docs/Architecture.md) - Understand the technical design\n- [Data Model](./docs/DataModel.md) - Explore the data structure\n\n### 🎯 I'm Evaluating This Solution\n- [Screenshots](./docs/screenshots/) - See the interface in action\n- [Use Cases](#common-use-cases) - Real-world scenarios below\n- [Features](#key-features) - What's included\n\n## Common Use Cases\n\n### 🏢 Multi-Branch Operations\n\n**Challenge**: 50 branch offices, each with unique phone numbers and custom greetings, but sharing the same contact flow logic.\n\n**Solution**: Create one flow configuration per branch (e.g., `branch-office-austin`, `branch-office-seattle`). Each branch gets custom prompts and settings while using a single, centralized contact flow design.\n\n**Result**: Onboard new branches in minutes. Local staff can update their own greetings and settings without IT involvement.\n\n---\n\n### 🚨 Emergency Response\n\n**Challenge**: Fire alarm requires immediate call center closure. Every minute of delay means confused customers and wasted agent time.\n\n**Solution**: Business users open FlowConfig, toggle `closure: true`, and save. All new calls immediately hear the closure message and are routed appropriately.\n\n**Result**: Response time measured in seconds, not hours. No contact flow changes, no deployments, no IT tickets.\n\n---\n\n### 🌍 Global Customer Support\n\n**Challenge**: Supporting customers in English, Spanish, and French requires managing hundreds of prompt variants across dozens of contact flows.\n\n**Solution**: Define prompts once in FlowConfig with all language variants. Contact flows automatically select the correct language based on customer preference.\n\n**Result**: Add a new language by updating prompts in FlowConfig—no contact flow changes required.\n\n---\n\n### 📊 Dynamic Queue Management\n\n**Challenge**: Call volume spikes require rapid adjustment of queue thresholds, wait times, and callback offerings.\n\n**Solution**: Business users adjust variables like `maxQueueDepth`, `maxWaitTime`, and `offerCallback` in real-time based on current conditions.\n\n**Result**: Contact center supervisors respond to changing conditions without waiting for IT or risking contact flow mistakes.\n\n---\n\n## Key Features\n\n**For Business Users:**\n- ✅ **No-Code Interface** - Simple web UI embedded in Amazon Connect Agent Workspace\n- 🎧 **Preview Before Publishing** - Hear exactly how prompts will sound using Amazon Polly text-to-speech\n- 🌍 **Multi-Language Support** - Manage prompts in multiple languages with separate voice and chat content\n- ⚡ **Instant Updates** - Changes take effect immediately for new customer contacts\n- 🔒 **Role-Based Access** - Three access levels: Admin, Edit, and Read-Only\n\n**For IT Teams:**\n- 🏗️ **Serverless Architecture** - Built on AWS Lambda, DynamoDB, and API Gateway\n- 🔌 **Native Connect Integration** - Seamlessly integrates with contact flows via Lambda function\n- 🔐 **Secure by Design** - AWS Cognito authentication with role-based access control\n- 📦 **Easy Deployment** - Single CDK construct deploys the entire stack\n- 🌐 **Flexible Architecture** - Supports single-region, multi-region, public, or VPC-private deployments\n- 📤 **Import/Export** - Move configurations between environments (dev/test/prod)\n\n---\n\n## Getting Started\n\n### For Developers\n\n**Installation:**\n\n```bash\nnpm install @cxbuilder/flow-config\n```\n\n**Basic Usage:**\n\n```typescript\nimport { FlowConfigStack } from '@cxbuilder/flow-config';\nimport * as cdk from 'aws-cdk-lib';\n\nconst app = new cdk.App();\nnew FlowConfigStack(app, 'FlowConfigStack', {\n  prefix: 'my-flow-config',\n  env: { region: 'us-east-1', account: 'YOUR_ACCOUNT_ID' },\n  cognito: {\n    domain: 'https://your-auth-domain.com',\n    userPoolId: 'us-east-1_YourPoolId',\n  },\n  connectInstanceArn: 'arn:aws:connect:us-east-1:YOUR_ACCOUNT:instance/YOUR_INSTANCE_ID',\n  alertEmails: ['admin@yourcompany.com'],\n});\n```\n\n**Next Steps:**\n- See the [Installation Guide](./docs/Installation.md) for detailed deployment instructions\n- Review the [Architecture](./docs/Architecture.md) to understand the technical design\n- Explore advanced configurations (VPC private, multi-region, etc.)\n\n### For Contact Flow Designers\n\n**Using FlowConfig in Your Contact Flows:**\n\n1. Add an \"Invoke AWS Lambda function\" block\n2. Select the GetConfig Lambda function (automatically deployed)\n3. Pass the configuration ID as a parameter:\n\n```json\n{\n  \"id\": \"main-queue\"\n}\n```\n\n4. Use the returned values in subsequent blocks:\n   - Variables: `$.External.closure`, `$.External.maxWaitTime`\n   - Prompts: `$.External.welcome`, `$.External.holdMessage`\n\n**Example Flow:**\n\n```\n[Entry Point] → [Invoke Lambda: GetConfig with id=\"main-queue\"]\n                      ↓\n                [Check: $.External.closure = true?]\n                      ↓                    ↓\n                  [Yes: Play           [No: Continue\n                   $.External.          to queue]\n                   closureMessage]\n```\n\nFor detailed Lambda integration instructions, see the [Technical Reference](#technical-reference) below.\n\n---\n\n## Technical Reference\n\n### GetConfig Lambda Integration\n\nThe GetConfig Lambda function is used within contact flows to access your flow configs. This function is automatically integrated with your Amazon Connect instance during deployment.\n\n**Lambda Parameters:**\n\n- **Required**: `id` - The flow configuration identifier\n- **Optional**: `lang` - Language code (defaults to contact's language or `en-US`)\n- **Auto-detected**: `channel` - Voice or chat (detected from contact data)\n\n**Lambda Response:**\n\nReturns a flattened object containing all variables and prompts from the configuration:\n\n```json\n{\n  \"closure\": \"false\",\n  \"maxWaitTime\": \"600\",\n  \"offerCallback\": \"true\",\n  \"welcome\": \"Thank you for calling...\",\n  \"holdMessage\": \"Please continue to hold...\"\n}\n```\n\n**Key Behaviors:**\n\n- Automatically selects the correct language variant based on customer preference\n- Returns chat-specific content for chat contacts (or strips SSML from voice content)\n- Includes all variables as key-value pairs\n- 32KB response size limit (Amazon Connect restriction)\n\n**Detailed Documentation:**\n\nFor complete API documentation, event structures, and advanced usage, see:\n- [Architecture Documentation](./docs/Architecture.md) - Full Lambda integration details\n- [Data Model](./docs/DataModel.md) - Configuration structure and schemas\n\n---\n\n## Development\n\nFor developers contributing to FlowConfig or customizing the deployment:\n\n**Frontend Development:**\n\n```bash\nnpm start              # Local dev server\nnpm run build          # Production build\n```\n\n**Lambda Development:**\n\n```bash\nnpm run build:lambdas  # Bundle Lambda functions\nnpm run build          # Full build (CDK + Frontend + Lambdas)\n```\n\n**Additional Resources:**\n- Uses [Lambda PowerTools](https://docs.powertools.aws.dev/lambda/typescript/latest/) for logging\n- OpenAPI spec for API Gateway enables client generation in any language\n- Frontend built with React and Amazon CloudScape Design System\n\nFor detailed development setup, see [Installation Guide](./docs/Installation.md).\n"
   },
   "repository": {
     "type": "git",
@@ -4614,6 +9103,6 @@
       "symbolId": "infrastructure/FlowConfigStack:LambdaVpcConfig"
     }
   },
-  "version": "2.2.0",
-  "fingerprint": "d5aIsBN6EfatPj+RWSwX3bJfoNsKhnBmCQxlGHI0RdU="
+  "version": "2.2.2",
+  "fingerprint": "jKSDGcd+EN2fOKFWqbndB0oMyGWt3JzWnuG9sv7DWt4="
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.2 (2026-01-05)
+
+- sfred
+  - Updated all backend and frontend npm dependencies to latest minor versions
+  - Backend: AWS SDK v3.962.0, constructs 10.4.4, jsii 5.9.22, and more
+  - Frontend: React 19.2.3, Cloudscape 3.0.1167, Vite 6.4.1, and more
+
 ## 2.2.1 (2025-12-16)
 
 - ivan.bliskavka

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,25 +8,25 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@amazon-connect/theme": "^1.0.3",
-        "@cloudscape-design/components": "^3.0.827",
-        "@cloudscape-design/global-styles": "^1.0.32",
+        "@amazon-connect/theme": "1.0.6",
+        "@cloudscape-design/components": "^3.0.1167",
+        "@cloudscape-design/global-styles": "^1.0.49",
         "loglevel": "^1.9.2",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3"
       },
       "devDependencies": {
-        "@eslint/js": "^9.25.0",
-        "@types/react": "^19.1.2",
-        "@types/react-dom": "^19.1.2",
-        "@vitejs/plugin-react": "^4.4.1",
-        "eslint": "^9.25.0",
+        "@eslint/js": "^9.39.2",
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^4.7.0",
+        "eslint": "^9.39.2",
         "eslint-plugin-react-hooks": "^5.2.0",
-        "eslint-plugin-react-refresh": "^0.4.19",
-        "globals": "^16.0.0",
+        "eslint-plugin-react-refresh": "^0.4.26",
+        "globals": "^16.5.0",
         "typescript": "~5.8.3",
-        "typescript-eslint": "^8.30.1",
-        "vite": "^6.3.5"
+        "typescript-eslint": "^8.52.0",
+        "vite": "^6.4.1"
       }
     },
     "node_modules/@amazon-connect/theme": {
@@ -36,20 +36,6 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@cloudscape-design/components": "^3.0.383"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -68,9 +54,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.27.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz",
-      "integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
+      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -78,22 +64,23 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
-      "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
+      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.3",
+        "@babel/generator": "^7.28.5",
         "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.27.3",
-        "@babel/helpers": "^7.27.4",
-        "@babel/parser": "^7.27.4",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.5",
         "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.27.4",
-        "@babel/types": "^7.27.3",
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -109,16 +96,16 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
-      "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
+      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@babel/types": "^7.27.3",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       },
       "engines": {
@@ -142,6 +129,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
@@ -157,15 +154,15 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.3"
+        "@babel/traverse": "^7.28.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -195,9 +192,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -215,27 +212,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.6"
+        "@babel/types": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
-      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.28.5"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -277,9 +274,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -301,72 +298,69 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
-      "integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.3",
-        "@babel/parser": "^7.27.4",
+        "@babel/generator": "^7.28.5",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.5",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.3",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/types": "^7.28.5",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/traverse/node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/types": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
-      "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@cloudscape-design/collection-hooks": {
-      "version": "1.0.73",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/collection-hooks/-/collection-hooks-1.0.73.tgz",
-      "integrity": "sha512-eWj+K2PR4RLSOxDl2fYNPAm+9cqvPr8va5KXthhC/K4tWDSqwFliG6x4vqgdmvifyNJIviD80p6zm8vdk5X27w==",
+      "version": "1.0.79",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/collection-hooks/-/collection-hooks-1.0.79.tgz",
+      "integrity": "sha512-StCX0ngMscurUbSyYVH/StHDRoJa4mXOaMv2i2T/Lcs7vzz9XoNGk15bpxdpFFsh08Z3yMiAD50FxS/K2Gdtug==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
     "node_modules/@cloudscape-design/component-toolkit": {
-      "version": "1.0.0-beta.101",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.101.tgz",
-      "integrity": "sha512-7G5X+pL1GXXseW6vJHEYIqj5Fotxk2m7I7h7vd/3m46eF4L2ZrGHj9vzuSYSqiJ5VtFYr4J9o/+YY/5g1cd7ZA==",
+      "version": "1.0.0-beta.131",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.131.tgz",
+      "integrity": "sha512-ZTx9loMjICU1M/+gnICAIh+QpkLAvwyLQEIXELxSz3NVNaX39dIrGBMStezTqEgv4sLgEA1xaVWc1Mrj0PqUNQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juggle/resize-observer": "^3.3.1",
-        "tslib": "^2.3.1"
+        "tslib": "^2.3.1",
+        "weekstart": "^2.0.0"
       }
     },
+    "node_modules/@cloudscape-design/component-toolkit/node_modules/weekstart": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/weekstart/-/weekstart-2.0.0.tgz",
+      "integrity": "sha512-HjYc14IQUwDcnGICuc8tVtqAd6EFpoAQMqgrqcNtWWZB+F1b7iTq44GzwM1qvnH4upFgbhJsaNHuK93NOFheSg==",
+      "license": "MIT"
+    },
     "node_modules/@cloudscape-design/components": {
-      "version": "3.0.985",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.985.tgz",
-      "integrity": "sha512-Ij3EFkGZoZNTtJBJXrYAioXU2L/hXJXwSPFWzSPFTGf41puenLJRZ2vAkv7xUNUUodh+rQRFlQIyk6h0nAt8+w==",
+      "version": "3.0.1167",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.1167.tgz",
+      "integrity": "sha512-xuqMnrT1WH3/ploap182FyXVNNZShuiMB5CV00hp5meked36lRcaUfpCIll3NpxI2pcc9FTOFii9cs5hL7vfqA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@cloudscape-design/collection-hooks": "^1.0.0",
         "@cloudscape-design/component-toolkit": "^1.0.0-beta",
@@ -375,9 +369,7 @@
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
-        "@juggle/resize-observer": "^3.3.1",
         "ace-builds": "^1.34.0",
-        "balanced-match": "^1.0.2",
         "clsx": "^1.1.0",
         "d3-shape": "^1.3.7",
         "date-fns": "^2.25.0",
@@ -393,15 +385,15 @@
       }
     },
     "node_modules/@cloudscape-design/global-styles": {
-      "version": "1.0.44",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/global-styles/-/global-styles-1.0.44.tgz",
-      "integrity": "sha512-cQmZ3tsbbMv4QZll0+NzmlUHjmQj0C+9s9nIf1KyV/sdVFGfeFLbV4K4cMmWeu2kOwg1fAE1QkjTI96SpUGM9w==",
+      "version": "1.0.49",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/global-styles/-/global-styles-1.0.49.tgz",
+      "integrity": "sha512-zN6zKKNJSDAsHtG700RtVuehfRMwBXOX7wi8P8X/ZXIIkAJ0n0RmhgVeP1r/tVHZCdTVof7HKB2DNjrtbMkNFg==",
       "license": "Apache-2.0"
     },
     "node_modules/@cloudscape-design/test-utils-core": {
-      "version": "1.0.59",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/test-utils-core/-/test-utils-core-1.0.59.tgz",
-      "integrity": "sha512-HtNYw0+hXWbOAyR3iA81VVZtHnzFZ9EUp9vShDYVDVSH5EwdlI3O589HjOU6jujojed7T57v3BLM3RK4cTekhQ==",
+      "version": "1.0.71",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/test-utils-core/-/test-utils-core-1.0.71.tgz",
+      "integrity": "sha512-4rXQlsd6Rdg+KCNoltLa1+0wjgNugbduuK7L4nTa/Aw/gJIYqrTU78ip5A2VmbDhiE6fiGqtCFmU6LcKCMP//A==",
       "license": "Apache-2.0",
       "dependencies": {
         "css-selector-tokenizer": "^0.8.0",
@@ -409,11 +401,12 @@
       }
     },
     "node_modules/@cloudscape-design/theming-runtime": {
-      "version": "1.0.79",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-runtime/-/theming-runtime-1.0.79.tgz",
-      "integrity": "sha512-OrpGamQZKoAXpjbDWVm9hz4DRl8XkO68M4qEp3JbZ9q1NddZ5pDRTQKFjnFmIbsBTVkMZEQdArI3BoYjQv7baw==",
+      "version": "1.0.90",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-runtime/-/theming-runtime-1.0.90.tgz",
+      "integrity": "sha512-QYFEj3CkfWscpefazwk2U+IP6uWKqr45KmvIbJtVbP80zN6sP8NwKhipxzxjM6tcLXKSc7KZCbsCV8GJXO0QGQ==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@material/material-color-utilities": "^0.3.0",
         "tslib": "^2.4.0"
       }
     },
@@ -434,6 +427,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -471,9 +465,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
@@ -488,9 +482,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
@@ -505,9 +499,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
@@ -522,9 +516,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
@@ -539,9 +533,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
@@ -556,9 +550,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
@@ -573,9 +567,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
@@ -590,9 +584,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
@@ -607,9 +601,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
@@ -624,9 +618,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
@@ -641,9 +635,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
@@ -658,9 +652,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
@@ -675,9 +669,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
@@ -692,9 +686,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
@@ -709,9 +703,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
@@ -726,9 +720,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
@@ -743,9 +737,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
@@ -760,9 +754,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "cpu": [
         "arm64"
       ],
@@ -777,9 +771,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
@@ -794,9 +788,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
       "cpu": [
         "arm64"
       ],
@@ -811,9 +805,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
@@ -827,10 +821,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
@@ -845,9 +856,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
@@ -862,9 +873,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
@@ -879,9 +890,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
@@ -896,9 +907,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -928,9 +939,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -938,13 +949,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
-      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -953,19 +964,22 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
-      "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -976,9 +990,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -988,7 +1002,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
@@ -1013,9 +1027,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz",
-      "integrity": "sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1026,9 +1040,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1036,13 +1050,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
-      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.14.0",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1050,13 +1064,13 @@
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
-      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
       "license": "MIT",
       "dependencies": {
         "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/intl-localematcher": "0.6.1",
+        "@formatjs/intl-localematcher": "0.6.2",
         "decimal.js": "^10.4.3",
         "tslib": "^2.8.0"
       }
@@ -1071,30 +1085,30 @@
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
-      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.4",
-        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
         "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
-      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/ecma402-abstract": "2.3.6",
         "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
-      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -1111,31 +1125,17 @@
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -1167,18 +1167,25 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1191,27 +1198,17 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1219,61 +1216,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@juggle/resize-observer": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
-      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+    "node_modules/@material/material-color-utilities": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@material/material-color-utilities/-/material-color-utilities-0.3.0.tgz",
+      "integrity": "sha512-ztmtTd6xwnuh2/xu+Vb01btgV8SQWYCaK56CkRK8gEkWe5TuDyBcYJ0wgkMRn+2VcE9KUmhvkz+N9GHrqw/C0g==",
       "license": "Apache-2.0"
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.9.tgz",
-      "integrity": "sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w==",
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.42.0.tgz",
-      "integrity": "sha512-gldmAyS9hpj+H6LpRNlcjQWbuKUtb94lodB9uCz71Jm+7BxK1VIOo7y62tZZwxhA7j1ylv/yQz080L5WkS+LoQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
+      "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
       "cpu": [
         "arm"
       ],
@@ -1285,9 +1244,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.42.0.tgz",
-      "integrity": "sha512-bpRipfTgmGFdCZDFLRvIkSNO1/3RGS74aWkJJTFJBH7h3MRV4UijkaEUeOMbi9wxtxYmtAbVcnMtHTPBhLEkaw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
+      "integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
       "cpu": [
         "arm64"
       ],
@@ -1299,9 +1258,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.42.0.tgz",
-      "integrity": "sha512-JxHtA081izPBVCHLKnl6GEA0w3920mlJPLh89NojpU2GsBSB6ypu4erFg/Wx1qbpUbepn0jY4dVWMGZM8gplgA==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
+      "integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
       "cpu": [
         "arm64"
       ],
@@ -1313,9 +1272,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.42.0.tgz",
-      "integrity": "sha512-rv5UZaWVIJTDMyQ3dCEK+m0SAn6G7H3PRc2AZmExvbDvtaDc+qXkei0knQWcI3+c9tEs7iL/4I4pTQoPbNL2SA==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
+      "integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
       "cpu": [
         "x64"
       ],
@@ -1327,9 +1286,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.42.0.tgz",
-      "integrity": "sha512-fJcN4uSGPWdpVmvLuMtALUFwCHgb2XiQjuECkHT3lWLZhSQ3MBQ9pq+WoWeJq2PrNxr9rPM1Qx+IjyGj8/c6zQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
+      "integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
       "cpu": [
         "arm64"
       ],
@@ -1341,9 +1300,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.42.0.tgz",
-      "integrity": "sha512-CziHfyzpp8hJpCVE/ZdTizw58gr+m7Y2Xq5VOuCSrZR++th2xWAz4Nqk52MoIIrV3JHtVBhbBsJcAxs6NammOQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
+      "integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
       "cpu": [
         "x64"
       ],
@@ -1355,9 +1314,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.42.0.tgz",
-      "integrity": "sha512-UsQD5fyLWm2Fe5CDM7VPYAo+UC7+2Px4Y+N3AcPh/LdZu23YcuGPegQly++XEVaC8XUTFVPscl5y5Cl1twEI4A==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
+      "integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
       "cpu": [
         "arm"
       ],
@@ -1369,9 +1328,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.42.0.tgz",
-      "integrity": "sha512-/i8NIrlgc/+4n1lnoWl1zgH7Uo0XK5xK3EDqVTf38KvyYgCU/Rm04+o1VvvzJZnVS5/cWSd07owkzcVasgfIkQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
+      "integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
       "cpu": [
         "arm"
       ],
@@ -1383,9 +1342,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.42.0.tgz",
-      "integrity": "sha512-eoujJFOvoIBjZEi9hJnXAbWg+Vo1Ov8n/0IKZZcPZ7JhBzxh2A+2NFyeMZIRkY9iwBvSjloKgcvnjTbGKHE44Q==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
       "cpu": [
         "arm64"
       ],
@@ -1397,9 +1356,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.42.0.tgz",
-      "integrity": "sha512-/3NrcOWFSR7RQUQIuZQChLND36aTU9IYE4j+TB40VU78S+RA0IiqHR30oSh6P1S9f9/wVOenHQnacs/Byb824g==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
+      "integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
       "cpu": [
         "arm64"
       ],
@@ -1410,10 +1369,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.42.0.tgz",
-      "integrity": "sha512-O8AplvIeavK5ABmZlKBq9/STdZlnQo7Sle0LLhVA7QT+CiGpNVe197/t8Aph9bhJqbDVGCHpY2i7QyfEDDStDg==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
+      "integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
       "cpu": [
         "loong64"
       ],
@@ -1424,10 +1383,38 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.42.0.tgz",
-      "integrity": "sha512-6Qb66tbKVN7VyQrekhEzbHRxXXFFD8QKiFAwX5v9Xt6FiJ3BnCVBuyBxa2fkFGqxOCSGGYNejxd8ht+q5SnmtA==",
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
+      "integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
+      "integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
+      "integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
       "cpu": [
         "ppc64"
       ],
@@ -1439,9 +1426,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.42.0.tgz",
-      "integrity": "sha512-KQETDSEBamQFvg/d8jajtRwLNBlGc3aKpaGiP/LvEbnmVUKlFta1vqJqTrvPtsYsfbE/DLg5CC9zyXRX3fnBiA==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
+      "integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
       "cpu": [
         "riscv64"
       ],
@@ -1453,9 +1440,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.42.0.tgz",
-      "integrity": "sha512-qMvnyjcU37sCo/tuC+JqeDKSuukGAd+pVlRl/oyDbkvPJ3awk6G6ua7tyum02O3lI+fio+eM5wsVd66X0jQtxw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
+      "integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
       "cpu": [
         "riscv64"
       ],
@@ -1467,9 +1454,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.42.0.tgz",
-      "integrity": "sha512-I2Y1ZUgTgU2RLddUHXTIgyrdOwljjkmcZ/VilvaEumtS3Fkuhbw4p4hgHc39Ypwvo2o7sBFNl2MquNvGCa55Iw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
+      "integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
       "cpu": [
         "s390x"
       ],
@@ -1481,9 +1468,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.42.0.tgz",
-      "integrity": "sha512-Gfm6cV6mj3hCUY8TqWa63DB8Mx3NADoFwiJrMpoZ1uESbK8FQV3LXkhfry+8bOniq9pqY1OdsjFWNsSbfjPugw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
       "cpu": [
         "x64"
       ],
@@ -1495,9 +1482,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.42.0.tgz",
-      "integrity": "sha512-g86PF8YZ9GRqkdi0VoGlcDUb4rYtQKyTD1IVtxxN4Hpe7YqLBShA7oHMKU6oKTCi3uxwW4VkIGnOaH/El8de3w==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
+      "integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
       "cpu": [
         "x64"
       ],
@@ -1508,10 +1495,38 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
+      "integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
+      "integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.42.0.tgz",
-      "integrity": "sha512-+axkdyDGSp6hjyzQ5m1pgcvQScfHnMCcsXkx8pTgy/6qBmWVhtRVlgxjWwDp67wEXXUr0x+vD6tp5W4x6V7u1A==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
+      "integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
       "cpu": [
         "arm64"
       ],
@@ -1523,9 +1538,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.42.0.tgz",
-      "integrity": "sha512-F+5J9pelstXKwRSDq92J0TEBXn2nfUrQGg+HK1+Tk7VOL09e0gBqUHugZv7SW4MGrYj41oNCUe3IKCDGVlis2g==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
+      "integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
       "cpu": [
         "ia32"
       ],
@@ -1536,10 +1551,24 @@
         "win32"
       ]
     },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.42.0.tgz",
-      "integrity": "sha512-LpHiJRwkaVz/LqjHjK8LCi8osq7elmpwujwbXKNW88bM8eeGxavJIKKjkjpMHAh/2xfnrt1ZSnhTv41WYUHYmA==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
+      "integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
       "cpu": [
         "x64"
       ],
@@ -1586,13 +1615,13 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
-      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.20.7"
+        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/estree": {
@@ -1609,54 +1638,42 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "24.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
-      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
+    "node_modules/@types/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "dependencies": {
-        "undici-types": "~7.8.0"
-      }
-    },
-    "node_modules/@types/react": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
-      "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
-      "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.33.1.tgz",
-      "integrity": "sha512-TDCXj+YxLgtvxvFlAvpoRv9MAncDLBV2oT9Bd7YBGC/b/sEURoOYuIwLI99rjWOfY3QtDzO+mk0n4AmdFExW8A==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.52.0.tgz",
+      "integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.33.1",
-        "@typescript-eslint/type-utils": "8.33.1",
-        "@typescript-eslint/utils": "8.33.1",
-        "@typescript-eslint/visitor-keys": "8.33.1",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.52.0",
+        "@typescript-eslint/type-utils": "8.52.0",
+        "@typescript-eslint/utils": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1666,9 +1683,9 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.33.1",
+        "@typescript-eslint/parser": "^8.52.0",
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -1682,17 +1699,18 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.1.tgz",
-      "integrity": "sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.52.0.tgz",
+      "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.33.1",
-        "@typescript-eslint/types": "8.33.1",
-        "@typescript-eslint/typescript-estree": "8.33.1",
-        "@typescript-eslint/visitor-keys": "8.33.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.52.0",
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/typescript-estree": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1703,19 +1721,19 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.1.tgz",
-      "integrity": "sha512-DZR0efeNklDIHHGRpMpR5gJITQpu6tLr9lDJnKdONTC7vvzOlLAG/wcfxcdxEWrbiZApcoBCzXqU/Z458Za5Iw==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.52.0.tgz",
+      "integrity": "sha512-xD0MfdSdEmeFa3OmVqonHi+Cciab96ls1UhIF/qX/O/gPu5KXD0bY9lu33jj04fjzrXHcuvjBcBC+D3SNSadaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.33.1",
-        "@typescript-eslint/types": "^8.33.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.52.0",
+        "@typescript-eslint/types": "^8.52.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1725,18 +1743,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.1.tgz",
-      "integrity": "sha512-dM4UBtgmzHR9bS0Rv09JST0RcHYearoEoo3pG5B6GoTR9XcyeqX87FEhPo+5kTvVfKCvfHaHrcgeJQc6mrDKrA==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.52.0.tgz",
+      "integrity": "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.33.1",
-        "@typescript-eslint/visitor-keys": "8.33.1"
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1747,9 +1765,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.1.tgz",
-      "integrity": "sha512-STAQsGYbHCF0/e+ShUQ4EatXQ7ceh3fBCXkNU7/MZVKulrlq1usH7t2FhxvCpuCi5O5oi1vmVaAjrGeL71OK1g==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.52.0.tgz",
+      "integrity": "sha512-jl+8fzr/SdzdxWJznq5nvoI7qn2tNYV/ZBAEcaFMVXf+K6jmXvAFrgo/+5rxgnL152f//pDEAYAhhBAZGrVfwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1760,20 +1778,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.33.1.tgz",
-      "integrity": "sha512-1cG37d9xOkhlykom55WVwG2QRNC7YXlxMaMzqw2uPeJixBFfKWZgaP/hjAObqMN/u3fr5BrTwTnc31/L9jQ2ww==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.52.0.tgz",
+      "integrity": "sha512-JD3wKBRWglYRQkAtsyGz1AewDu3mTc7NtRjR/ceTyGoPqmdS5oCdx/oZMWD5Zuqmo6/MpsYs0wp6axNt88/2EQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.33.1",
-        "@typescript-eslint/utils": "8.33.1",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/typescript-estree": "8.52.0",
+        "@typescript-eslint/utils": "8.52.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1784,13 +1803,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.1.tgz",
-      "integrity": "sha512-xid1WfizGhy/TKMTwhtVOgalHwPtV8T32MS9MaH50Cwvz6x6YqRIPdD2WvW0XaqOzTV9p5xdLY0h/ZusU5Lokg==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.52.0.tgz",
+      "integrity": "sha512-LWQV1V4q9V4cT4H5JCIx3481iIFxH1UkVk+ZkGGAV1ZGcjGI9IoFOfg3O6ywz8QqCDEp7Inlg6kovMofsNRaGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1802,22 +1821,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.1.tgz",
-      "integrity": "sha512-+s9LYcT8LWjdYWu7IWs7FvUxpQ/DGkdjZeE/GGulHvv8rvYwQvVaUZ6DE+j5x/prADUgSbbCWZ2nPI3usuVeOA==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.52.0.tgz",
+      "integrity": "sha512-XP3LClsCc0FsTK5/frGjolyADTh3QmsLp6nKd476xNI9CsSsLnmn4f0jrzNoAulmxlmNIpeXuHYeEQv61Q6qeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.33.1",
-        "@typescript-eslint/tsconfig-utils": "8.33.1",
-        "@typescript-eslint/types": "8.33.1",
-        "@typescript-eslint/visitor-keys": "8.33.1",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/project-service": "8.52.0",
+        "@typescript-eslint/tsconfig-utils": "8.52.0",
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/visitor-keys": "8.52.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1827,13 +1845,13 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1857,9 +1875,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1870,16 +1888,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.1.tgz",
-      "integrity": "sha512-52HaBiEQUaRYqAXpfzWSR2U3gxk92Kw006+xZpElaPMg3C4PgM+A5LqwoQI1f9E5aZ/qlxAZxzm42WX+vn92SQ==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.52.0.tgz",
+      "integrity": "sha512-wYndVMWkweqHpEpwPhwqE2lnD2DxC6WVLupU/DOt/0/v+/+iQbbzO3jOHjmBMnhu0DgLULvOaU4h4pwHYi2oRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.33.1",
-        "@typescript-eslint/types": "8.33.1",
-        "@typescript-eslint/typescript-estree": "8.33.1"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.52.0",
+        "@typescript-eslint/types": "8.52.0",
+        "@typescript-eslint/typescript-estree": "8.52.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1890,18 +1908,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.1.tgz",
-      "integrity": "sha512-3i8NrFcZeeDHJ+7ZUuDkGT+UHq+XoFGsymNK2jZCOHcfEzRQ0BdpRtdpSx/Iyf3MHLWIcLS0COuOPibKQboIiQ==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.52.0.tgz",
+      "integrity": "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.33.1",
-        "eslint-visitor-keys": "^4.2.0"
+        "@typescript-eslint/types": "8.52.0",
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1912,16 +1930,16 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.5.1.tgz",
-      "integrity": "sha512-uPZBqSI0YD4lpkIru6M35sIfylLGTyhGHvDZbNLuMA73lMlwJKz5xweH7FajfcCAc2HnINciejA9qTz0dr0M7A==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.26.10",
-        "@babel/plugin-transform-react-jsx-self": "^7.25.9",
-        "@babel/plugin-transform-react-jsx-source": "^7.25.9",
-        "@rolldown/pluginutils": "1.0.0-beta.9",
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
         "@types/babel__core": "^7.20.5",
         "react-refresh": "^0.17.0"
       },
@@ -1929,13 +1947,13 @@
         "node": "^14.18.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.42.0.tgz",
-      "integrity": "sha512-nRDbpHguujCh9Lb00jtJAblR6d5JEi6RVrHtj+TAlUqRYwWl5Es7iHnyXUOmTcMfkzQ2/TPn45G/yvdQGa0ZXw==",
+      "version": "1.43.5",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.43.5.tgz",
+      "integrity": "sha512-iH5FLBKdB7SVn9GR37UgA/tpQS8OTWIxWAuq3Ofaw+Qbc69FfPXsXd9jeW7KRG2xKpKMqBDnu0tHBrCWY5QI7A==",
       "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
@@ -1944,6 +1962,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2005,12 +2024,23 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.11",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
+      "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2018,23 +2048,10 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/browserslist": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
-      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
       "funding": [
         {
@@ -2051,11 +2068,13 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001718",
-        "electron-to-chromium": "^1.5.160",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2075,9 +2094,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001721",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001721.tgz",
-      "integrity": "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ==",
+      "version": "1.0.30001762",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
+      "integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
       "dev": true,
       "funding": [
         {
@@ -2199,9 +2218,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/d3-path": {
@@ -2236,9 +2255,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2254,9 +2273,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -2277,16 +2296,16 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.165",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.165.tgz",
-      "integrity": "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw==",
+      "version": "1.5.267",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
+      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/esbuild": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2297,31 +2316,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.5",
-        "@esbuild/android-arm": "0.25.5",
-        "@esbuild/android-arm64": "0.25.5",
-        "@esbuild/android-x64": "0.25.5",
-        "@esbuild/darwin-arm64": "0.25.5",
-        "@esbuild/darwin-x64": "0.25.5",
-        "@esbuild/freebsd-arm64": "0.25.5",
-        "@esbuild/freebsd-x64": "0.25.5",
-        "@esbuild/linux-arm": "0.25.5",
-        "@esbuild/linux-arm64": "0.25.5",
-        "@esbuild/linux-ia32": "0.25.5",
-        "@esbuild/linux-loong64": "0.25.5",
-        "@esbuild/linux-mips64el": "0.25.5",
-        "@esbuild/linux-ppc64": "0.25.5",
-        "@esbuild/linux-riscv64": "0.25.5",
-        "@esbuild/linux-s390x": "0.25.5",
-        "@esbuild/linux-x64": "0.25.5",
-        "@esbuild/netbsd-arm64": "0.25.5",
-        "@esbuild/netbsd-x64": "0.25.5",
-        "@esbuild/openbsd-arm64": "0.25.5",
-        "@esbuild/openbsd-x64": "0.25.5",
-        "@esbuild/sunos-x64": "0.25.5",
-        "@esbuild/win32-arm64": "0.25.5",
-        "@esbuild/win32-ia32": "0.25.5",
-        "@esbuild/win32-x64": "0.25.5"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escalade": {
@@ -2348,33 +2368,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
-      "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.0",
-        "@eslint/config-helpers": "^0.2.1",
-        "@eslint/core": "^0.14.0",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.28.0",
-        "@eslint/plugin-kit": "^0.3.1",
+        "@eslint/js": "9.39.2",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.3.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2422,9 +2442,9 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.20.tgz",
-      "integrity": "sha512-XpbHQ2q5gUF8BGOX4dHe+71qoirYMhApEPZ7sfhF/dNnOF1UXnCMGZf79SFTBO7Bz5YEIT4TMieSlJBWhP9WBA==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
+      "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2432,9 +2452,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
-      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2449,9 +2469,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2462,15 +2482,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2480,9 +2500,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2532,36 +2552,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2582,14 +2572,22 @@
       "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
       "license": "MIT"
     },
-    "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/file-entry-cache": {
@@ -2603,19 +2601,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -2695,9 +2680,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
-      "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2706,13 +2691,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -2762,14 +2740,14 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "10.7.16",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
-      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/ecma402-abstract": "2.3.6",
         "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
         "tslib": "^2.8.0"
       }
     },
@@ -2796,16 +2774,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2820,9 +2788,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2961,30 +2929,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3044,9 +2988,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3150,22 +3094,23 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
-      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
       "funding": [
         {
@@ -3228,46 +3173,27 @@
         "node": ">=6"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
+      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^19.2.3"
       }
     },
     "node_modules/react-is": {
@@ -3324,25 +3250,14 @@
         "node": ">=4"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rollup": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.42.0.tgz",
-      "integrity": "sha512-LW+Vse3BJPyGJGAJt1j8pWDKPd73QM8cRXYK1IxOBgL2AGLu7Xd2YOW0M2sLUBCkF5MshXXtMApyEAEzMVMsnw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
+      "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.7"
+        "@types/estree": "1.0.8"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3352,64 +3267,38 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.42.0",
-        "@rollup/rollup-android-arm64": "4.42.0",
-        "@rollup/rollup-darwin-arm64": "4.42.0",
-        "@rollup/rollup-darwin-x64": "4.42.0",
-        "@rollup/rollup-freebsd-arm64": "4.42.0",
-        "@rollup/rollup-freebsd-x64": "4.42.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.42.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.42.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.42.0",
-        "@rollup/rollup-linux-arm64-musl": "4.42.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.42.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.42.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.42.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.42.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.42.0",
-        "@rollup/rollup-linux-x64-gnu": "4.42.0",
-        "@rollup/rollup-linux-x64-musl": "4.42.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.42.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.42.0",
-        "@rollup/rollup-win32-x64-msvc": "4.42.0",
+        "@rollup/rollup-android-arm-eabi": "4.55.1",
+        "@rollup/rollup-android-arm64": "4.55.1",
+        "@rollup/rollup-darwin-arm64": "4.55.1",
+        "@rollup/rollup-darwin-x64": "4.55.1",
+        "@rollup/rollup-freebsd-arm64": "4.55.1",
+        "@rollup/rollup-freebsd-x64": "4.55.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.55.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.55.1",
+        "@rollup/rollup-linux-arm64-musl": "4.55.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.55.1",
+        "@rollup/rollup-linux-loong64-musl": "4.55.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.55.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.55.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.55.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.55.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-musl": "4.55.1",
+        "@rollup/rollup-openbsd-x64": "4.55.1",
+        "@rollup/rollup-openharmony-arm64": "4.55.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.55.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.55.1",
+        "@rollup/rollup-win32-x64-gnu": "4.55.1",
+        "@rollup/rollup-win32-x64-msvc": "4.55.1",
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup/node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -3482,14 +3371,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3498,51 +3387,10 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
-      "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3577,6 +3425,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3586,15 +3435,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.33.1.tgz",
-      "integrity": "sha512-AgRnV4sKkWOiZ0Kjbnf5ytTJXMUZQ0qhSVdQtDNYLPLnjsATEYhaO94GlRQwi4t4gO8FfjM6NnikHeKjUm8D7A==",
+      "version": "8.52.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.52.0.tgz",
+      "integrity": "sha512-atlQQJ2YkO4pfTVQmQ+wvYQwexPDOIgo+RaVcD7gHgzy/IQA+XTyuxNM9M9TVXvttkF7koBHmcwisKdOAf2EcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.33.1",
-        "@typescript-eslint/parser": "8.33.1",
-        "@typescript-eslint/utils": "8.33.1"
+        "@typescript-eslint/eslint-plugin": "8.52.0",
+        "@typescript-eslint/parser": "8.52.0",
+        "@typescript-eslint/typescript-estree": "8.52.0",
+        "@typescript-eslint/utils": "8.52.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3605,22 +3455,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -3659,11 +3500,12 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -3731,34 +3573,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/fdir": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
-      "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/weekstart": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,24 +10,24 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@amazon-connect/theme": "^1.0.3",
-    "@cloudscape-design/components": "^3.0.827",
-    "@cloudscape-design/global-styles": "^1.0.32",
+    "@amazon-connect/theme": "1.0.6",
+    "@cloudscape-design/components": "^3.0.1167",
+    "@cloudscape-design/global-styles": "^1.0.49",
     "loglevel": "^1.9.2",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "@eslint/js": "^9.25.0",
-    "@types/react": "^19.1.2",
-    "@types/react-dom": "^19.1.2",
-    "@vitejs/plugin-react": "^4.4.1",
-    "eslint": "^9.25.0",
+    "@eslint/js": "^9.39.2",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^4.7.0",
+    "eslint": "^9.39.2",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "eslint-plugin-react-refresh": "^0.4.19",
-    "globals": "^16.0.0",
+    "eslint-plugin-react-refresh": "^0.4.26",
+    "globals": "^16.5.0",
     "typescript": "~5.8.3",
-    "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "typescript-eslint": "^8.52.0",
+    "vite": "^6.4.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cxbuilder/flow-config",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cxbuilder/flow-config",
-      "version": "2.1.2",
+      "version": "2.2.1",
       "bundleDependencies": [
         "@aws-sdk/client-cloudformation",
         "@aws-sdk/client-connect",
@@ -20,44 +20,44 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-cloudformation": "^3.826.0",
-        "@aws-sdk/client-connect": "^3.826.0",
-        "@aws-sdk/client-dynamodb": "^3.826.0",
-        "@aws-sdk/client-lambda": "^3.826.0",
-        "@aws-sdk/client-polly": "^3.826.0",
-        "@aws-sdk/client-sns": "^3.826.0",
-        "@aws-sdk/lib-dynamodb": "^3.826.0",
+        "@aws-sdk/client-cloudformation": "^3.962.0",
+        "@aws-sdk/client-connect": "^3.962.0",
+        "@aws-sdk/client-dynamodb": "^3.962.0",
+        "@aws-sdk/client-lambda": "^3.962.0",
+        "@aws-sdk/client-polly": "^3.962.0",
+        "@aws-sdk/client-sns": "^3.962.0",
+        "@aws-sdk/lib-dynamodb": "^3.962.0",
         "mime-types": "^2.1.35",
-        "yaml": "^2.8.0"
+        "yaml": "^2.8.2"
       },
       "devDependencies": {
-        "@aws-lambda-powertools/logger": "^2.21.0",
-        "@types/aws-lambda": "^8.10.149",
+        "@aws-lambda-powertools/logger": "^2.30.0",
+        "@types/aws-lambda": "^8.10.159",
         "@types/jest": "^29.5.14",
         "@types/mime-types": "^2.1.4",
-        "@types/node": "22.7.9",
-        "aws-cdk": "2.1014.0",
-        "aws-cdk-lib": "2.194.0",
+        "@types/node": "22.15.32",
+        "aws-cdk": "2.1100.2",
+        "aws-cdk-lib": "2.233.0",
         "aws-sdk-client-mock": "^4.1.0",
         "aws-sdk-client-mock-jest": "^4.1.0",
-        "constructs": "10.0.0",
+        "constructs": "10.4.4",
         "cpx": "^1.5.0",
-        "esbuild": "^0.25.5",
+        "esbuild": "^0.25.12",
         "jest": "^29.7.0",
-        "jsii": "^5.8.12",
-        "jsii-pacmak": "^1.112.0",
-        "openapi-typescript": "^7.4.3",
-        "publib": "^0.2.999",
-        "rimraf": "^6.0.1",
-        "ts-jest": "^29.2.5",
+        "jsii": "^5.9.22",
+        "jsii-pacmak": "^1.125.0",
+        "openapi-typescript": "^7.10.1",
+        "publib": "^0.2.1027",
+        "rimraf": "^6.1.2",
+        "ts-jest": "^29.4.6",
         "ts-node": "^10.9.2",
         "typescript": "~5.6.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.194.0",
+        "aws-cdk-lib": "2.233.0",
         "constructs": "^10.0.0"
       }
     },
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.239",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.239.tgz",
-      "integrity": "sha512-dhs0hKNk/PCvpoJb/WIePrWbwieNMxfW/hS2aJLRv6QIh6M6DSPAxhJ2d7ALg8pfk2NQhHpKERNGB4KUiCodmg==",
+      "version": "2.2.242",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.242.tgz",
+      "integrity": "sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -90,9 +90,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "41.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
-      "integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
+      "version": "48.20.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-48.20.0.tgz",
+      "integrity": "sha512-+eeiav9LY4wbF/EFuCt/vfvi/Zoxo8bf94PW5clbMraChEliq83w4TbRVy0jB9jE0v1ooFTtIjSQkowSPkfISg==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -101,10 +101,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.1"
+        "semver": "^7.7.2"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
@@ -117,7 +117,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.1",
+      "version": "7.7.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -279,24 +279,28 @@
       }
     },
     "node_modules/@aws-lambda-powertools/commons": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-2.21.0.tgz",
-      "integrity": "sha512-8AXwZv3k5Ey/9xyW9fsTgHDhayJswvDi94yfNNX0zbe/8lZouTPePYWfffJegJDOaN1nkNoCQQD2pS3v5QLB/Q==",
-      "dev": true,
-      "license": "MIT-0"
-    },
-    "node_modules/@aws-lambda-powertools/logger": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-2.21.0.tgz",
-      "integrity": "sha512-neurPYJzkt3nSxiF3MJGzJa09/w7SR2Mhq0RAM8tbXetSm0e6o9TkIbGaYbK1LcXEXLtDmqO6n0JnJ/y5ZqWvA==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-2.30.0.tgz",
+      "integrity": "sha512-5kjamCPR/dIEHIk4BAFDSO/MgF21qL/q/f5AKi3GEOdvULuLcbw40xneMmPXo4ETaBSe+BHvovWLuI0Jl9BEnw==",
       "dev": true,
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^2.21.0",
+        "@aws/lambda-invoke-store": "0.2.2"
+      }
+    },
+    "node_modules/@aws-lambda-powertools/logger": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-2.30.0.tgz",
+      "integrity": "sha512-ejmuzn8KNi7CrhJSnl4a/SLAjcmlHJPvH55QpSZvj8K8aQLhOKcCpd0u+gXp0oYlj50d22h9ZV5qtIn7O8V4Lw==",
+      "dev": true,
+      "license": "MIT-0",
+      "dependencies": {
+        "@aws-lambda-powertools/commons": "2.30.0",
+        "@aws/lambda-invoke-store": "0.2.2",
         "lodash.merge": "^4.6.2"
       },
       "peerDependencies": {
-        "@aws-lambda-powertools/jmespath": "2.x",
+        "@aws-lambda-powertools/jmespath": "2.30.0",
         "@middy/core": "4.x || 5.x || 6.x"
       },
       "peerDependenciesMeta": {
@@ -309,852 +313,316 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudformation": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.826.0.tgz",
-      "integrity": "sha512-jo9d7PSBFbS+gKsYtOh3QZach/miMVi5fOoiPkUxCoXRQVsvEkOeEKyPrL85rp+u4/C77EoIufzDVRoTJq3cKQ==",
+      "version": "3.962.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.962.0.tgz",
+      "integrity": "sha512-ypZzDM2D/8m5N9MecnDFKHQw7Vn+eWG9a2cvIKTBvbO8RUxC2vHXjqSNiPiD9veWjlmd+n2fo4govb1KrQd+pw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-node": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.826.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.821.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.826.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.5",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/credential-provider-node": "3.962.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.957.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.7",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-codeartifact": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-codeartifact/-/client-codeartifact-3.830.0.tgz",
-      "integrity": "sha512-w9ulBaK3xUWtN0Pzjmjf1ZWqLOH3U44ETttl44kAgyL0WlVDld5yQ2ha8hCLmjDxHya8EmE2Q+SENaNKAA1yHg==",
+      "version": "3.962.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-codeartifact/-/client-codeartifact-3.962.0.tgz",
+      "integrity": "sha512-rPObCvA8w92e8k/IVv2AYBvMwuj3zsN9N9LSTGTwT8CjDIBjfREWwEX/XchJY3s0/bpLhv4OcZQ9OHlpgYPsmw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-node": "3.830.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-stream": "^4.2.2",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/credential-provider-node": "3.962.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.957.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-stream": "^4.5.8",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codeartifact/node_modules/@aws-sdk/client-sso": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.830.0.tgz",
-      "integrity": "sha512-5zCEpfI+zwX2SIa258L+TItNbBoAvQQ6w74qdFM6YJufQ1F9tvwjTX8T+eSTT9nsFIvfYnUaGalWwJVfmJUgVQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codeartifact/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.830.0.tgz",
-      "integrity": "sha512-zeQenzvh8JRY5nULd8izdjVGoCM1tgsVVsrLSwDkHxZTTW0hW/bmOmXfvdaE0wDdomXW7m2CkQDSmP7XdvNXZg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.830.0",
-        "@aws-sdk/credential-provider-web-identity": "3.830.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codeartifact/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.830.0.tgz",
-      "integrity": "sha512-X/2LrTgwtK1pkWrvofxQBI8VTi6QVLtSMpsKKPPnJQ0vgqC0e4czSIs3ZxiEsOkCBaQ2usXSiKyh0ccsQ6k2OA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-ini": "3.830.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.830.0",
-        "@aws-sdk/credential-provider-web-identity": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codeartifact/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.830.0.tgz",
-      "integrity": "sha512-+VdRpZmfekzpySqZikAKx6l5ndnLGluioIgUG4ZznrButgFD/iogzFtGmBDFB3ZLViX1l4pMXru0zFwJEZT21Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.830.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/token-providers": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codeartifact/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.830.0.tgz",
-      "integrity": "sha512-hPYrKsZeeOdLROJ59T6Y8yZ0iwC/60L3qhZXjapBFjbqBtMaQiMTI645K6xVXBioA6vxXq7B4aLOhYqk6Fy/Ww==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codeartifact/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.828.0.tgz",
-      "integrity": "sha512-nixvI/SETXRdmrVab4D9LvXT3lrXkwAWGWk2GVvQvzlqN1/M/RfClj+o37Sn4FqRkGH9o9g7Fqb1YqZ4mqDAtA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@smithy/core": "^3.5.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codeartifact/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.830.0.tgz",
-      "integrity": "sha512-5N5YTlBr1vtxf7+t+UaIQ625KEAmm7fY9o1e3MgGOi/paBoI0+axr3ud24qLIy0NSzFlAHEaxUSWxcERNjIoZw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codeartifact/node_modules/@aws-sdk/token-providers": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.830.0.tgz",
-      "integrity": "sha512-aJ4guFwj92nV9D+EgJPaCFKK0I3y2uMchiDfh69Zqnmwfxxxfxat6F79VA7PS0BdbjRfhLbn+Ghjftnomu2c1g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codeartifact/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.828.0.tgz",
-      "integrity": "sha512-RvKch111SblqdkPzg3oCIdlGxlQs+k+P7Etory9FmxPHyPDvsP1j1c74PmgYqtzzMWmoXTjd+c9naUHh9xG8xg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-endpoints": "^3.0.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-codeartifact/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.828.0.tgz",
-      "integrity": "sha512-LdN6fTBzTlQmc8O8f1wiZN0qF3yBWVGis7NwpWK7FUEzP9bEZRxYfIkV9oV9zpt6iNRze1SedK3JQVB/udxBoA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.830.0.tgz",
-      "integrity": "sha512-YhhQNVmHykPC6h6Xj60BMG7ELxxlynwNW2wK+8HJRiT62nYhbDyHypY9W2zNshqh/SE+5gLvwt1sXAu7KHGWmQ==",
+      "version": "3.962.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.962.0.tgz",
+      "integrity": "sha512-gQKsnvC4Rlg0uVSDZIo5Ditp/oqea21omsJsftqkAXGyFQsNVLMd1Toz0Akg0ecbLoLhrWPCMylugH6El1buYw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-node": "3.830.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/credential-provider-node": "3.962.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.957.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.830.0.tgz",
-      "integrity": "sha512-5zCEpfI+zwX2SIa258L+TItNbBoAvQQ6w74qdFM6YJufQ1F9tvwjTX8T+eSTT9nsFIvfYnUaGalWwJVfmJUgVQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.830.0.tgz",
-      "integrity": "sha512-zeQenzvh8JRY5nULd8izdjVGoCM1tgsVVsrLSwDkHxZTTW0hW/bmOmXfvdaE0wDdomXW7m2CkQDSmP7XdvNXZg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.830.0",
-        "@aws-sdk/credential-provider-web-identity": "3.830.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.830.0.tgz",
-      "integrity": "sha512-X/2LrTgwtK1pkWrvofxQBI8VTi6QVLtSMpsKKPPnJQ0vgqC0e4czSIs3ZxiEsOkCBaQ2usXSiKyh0ccsQ6k2OA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-ini": "3.830.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.830.0",
-        "@aws-sdk/credential-provider-web-identity": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.830.0.tgz",
-      "integrity": "sha512-+VdRpZmfekzpySqZikAKx6l5ndnLGluioIgUG4ZznrButgFD/iogzFtGmBDFB3ZLViX1l4pMXru0zFwJEZT21Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.830.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/token-providers": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.830.0.tgz",
-      "integrity": "sha512-hPYrKsZeeOdLROJ59T6Y8yZ0iwC/60L3qhZXjapBFjbqBtMaQiMTI645K6xVXBioA6vxXq7B4aLOhYqk6Fy/Ww==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.828.0.tgz",
-      "integrity": "sha512-nixvI/SETXRdmrVab4D9LvXT3lrXkwAWGWk2GVvQvzlqN1/M/RfClj+o37Sn4FqRkGH9o9g7Fqb1YqZ4mqDAtA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@smithy/core": "^3.5.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.830.0.tgz",
-      "integrity": "sha512-5N5YTlBr1vtxf7+t+UaIQ625KEAmm7fY9o1e3MgGOi/paBoI0+axr3ud24qLIy0NSzFlAHEaxUSWxcERNjIoZw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/token-providers": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.830.0.tgz",
-      "integrity": "sha512-aJ4guFwj92nV9D+EgJPaCFKK0I3y2uMchiDfh69Zqnmwfxxxfxat6F79VA7PS0BdbjRfhLbn+Ghjftnomu2c1g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.828.0.tgz",
-      "integrity": "sha512-RvKch111SblqdkPzg3oCIdlGxlQs+k+P7Etory9FmxPHyPDvsP1j1c74PmgYqtzzMWmoXTjd+c9naUHh9xG8xg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-endpoints": "^3.0.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.828.0.tgz",
-      "integrity": "sha512-LdN6fTBzTlQmc8O8f1wiZN0qF3yBWVGis7NwpWK7FUEzP9bEZRxYfIkV9oV9zpt6iNRze1SedK3JQVB/udxBoA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
       }
     },
     "node_modules/@aws-sdk/client-connect": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-connect/-/client-connect-3.826.0.tgz",
-      "integrity": "sha512-DcM+iUTsnV7kqzgQYz81hQx3sQwWGxebTWfBZqlbOBUPpH8V/id73mlhN0/BIR1Tk6xnTGDQ1I90lQV99paw8g==",
+      "version": "3.962.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-connect/-/client-connect-3.962.0.tgz",
+      "integrity": "sha512-xXHp0yzvLH5AKIL3VbpIyXSdRPXKTAGeLa2u2kuwF3pYJixGdmnydXODS9r4npI27/+LUHSONEVR30owh+xJtA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-node": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.826.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.821.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.826.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/credential-provider-node": "3.962.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.957.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.826.0.tgz",
-      "integrity": "sha512-EtgX1IqnrywGBREFuLTI6Va7I2SfL4RGxSONLi3NRHsmVh3/D5cV4imfrCDJ2I2vMOwk46/X6YDTS/Oz8uP/OQ==",
+      "version": "3.962.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.962.0.tgz",
+      "integrity": "sha512-q2pI7t3Jdwi+sOWdfZSTtnQVUbgEP+Lg0IbU6f6zhPRKDz8UWWYpKHaImRTbiSILN6UlPhIll8odfpxWxFUiwg==",
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-node": "3.826.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.821.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.826.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.821.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.826.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.5",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/credential-provider-node": "3.962.0",
+        "@aws-sdk/dynamodb-codec": "3.957.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.957.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.957.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.7",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.826.0.tgz",
-      "integrity": "sha512-RWkzP6yZ7YZ856ibtab9TYC8zzm7uc0zOcG78moNrIwr3b9yacXrIjRAcRQ6RApYhiVEr4F5CIHyrjgwcDfelQ==",
+      "version": "3.962.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.962.0.tgz",
+      "integrity": "sha512-4+f4zY54y83yiLHzcn6LnAppR3TlW54kVbsFS4JmOdE91fmVQedGpkgytjofD+qqIYALYxo5g7vWEUkfK08XPg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-node": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.826.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.821.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.826.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/eventstream-serde-browser": "^4.0.4",
-        "@smithy/eventstream-serde-config-resolver": "^4.1.2",
-        "@smithy/eventstream-serde-node": "^4.0.4",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-stream": "^4.2.2",
-        "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.5",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/credential-provider-node": "3.962.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.957.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/eventstream-serde-browser": "^4.2.7",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.7",
+        "@smithy/eventstream-serde-node": "^4.2.7",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-stream": "^4.5.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.7",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1162,51 +630,51 @@
       }
     },
     "node_modules/@aws-sdk/client-polly": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-polly/-/client-polly-3.826.0.tgz",
-      "integrity": "sha512-FvTYWks3L3DZwVMxCetFC+pl4VXx5nMGBPY3l1009H0LMYnNOl0OBCfGwoW1JvA24A8I6Jd3CrqeEpWjnT2SuQ==",
+      "version": "3.962.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-polly/-/client-polly-3.962.0.tgz",
+      "integrity": "sha512-Zy//20X6sLoWR2nhVNw11f83V3Gu13CiGrzHnof9ipL/8zicn8XZEBSANwjCjOU5pvAJCW4uWpQUAXlb3cuk2A==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-node": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.826.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.821.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.826.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-stream": "^4.2.2",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/credential-provider-node": "3.962.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.957.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-stream": "^4.5.8",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1214,50 +682,50 @@
       }
     },
     "node_modules/@aws-sdk/client-sns": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.826.0.tgz",
-      "integrity": "sha512-nGx2B2EbdeZu4mkeFUf7cnxQjtCj6zuhLXg/Liswz4+UfjQ/fS45Mxv2I932Xz2XmXscciJBRz7V5V/zG70SXw==",
+      "version": "3.962.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.962.0.tgz",
+      "integrity": "sha512-+R6royTAbae2Mkdtv8hfJpsaEHY8HibcWIkTHLRAcY+9DMIBW10UrC9ZUTKyHnNCASPrlWaIqXWHg+3e+CuGXw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-node": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.826.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.821.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.826.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/credential-provider-node": "3.962.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.957.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1265,49 +733,49 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.826.0.tgz",
-      "integrity": "sha512-/FEKnUC3xPkLL4RuRydwzx+y4b55HIX6qLPbGnyIs+sNmCUyc/62ijtV1Ml+b++YzEF6jWNBsJOxeyZdgrJ3Ig==",
+      "version": "3.958.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.958.0.tgz",
+      "integrity": "sha512-6qNCIeaMzKzfqasy2nNRuYnMuaMebCcCPP4J2CVGkA8QYMbIVKPlkn9bpB20Vxe6H/r3jtCCLQaOJjVTx/6dXg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.826.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.821.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.826.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.957.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1315,26 +783,24 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.826.0.tgz",
-      "integrity": "sha512-BGbQYzWj3ps+dblq33FY5tz/SsgJCcXX0zjQlSC07tYvU1jHTUvsefphyig+fY38xZ4wdKjbTop+KUmXUYrOXw==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.957.0.tgz",
+      "integrity": "sha512-DrZgDnF1lQZv75a52nFWs6MExihJF2GZB6ETZRqr6jMwhrk2kbJPUtvgbifwcL7AYmVqHQDJBrR/MqkwwFCpiw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/xml-builder": "3.821.0",
-        "@smithy/core": "^3.5.3",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/signature-v4": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-utf8": "^4.0.0",
-        "fast-xml-parser": "4.4.1",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/xml-builder": "3.957.0",
+        "@smithy/core": "^3.20.0",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/signature-v4": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1342,16 +808,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.830.0.tgz",
-      "integrity": "sha512-YEXmJ1BJ6DzjNnW5OR/5yNPm5d19uifKM6n/1Q1+vooj0OC/zxO9rXo5uQ8Kjs7ZAb0uYSxzy5pTNi5Ilvs8+Q==",
+      "version": "3.962.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.962.0.tgz",
+      "integrity": "sha512-0B1iwgCNY3cg/s3JwWtBP1PaB4uldd0sgx6WgVVcnQ9rpyuCMOUF61enA1OcmSWgRRndylznGXjok8cva5Pw4w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/client-cognito-identity": "3.962.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1359,16 +825,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.826.0.tgz",
-      "integrity": "sha512-DK3pQY8+iKK3MGDdC3uOZQ2psU01obaKlTYhEwNu4VWzgwQL4Vi3sWj4xSWGEK41vqZxiRLq6fOq7ysRI+qEZA==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.957.0.tgz",
+      "integrity": "sha512-475mkhGaWCr+Z52fOOVb/q2VHuNvqEDixlYIkeaO6xJ6t9qR0wpLt4hOQaR6zR1wfZV0SlE7d8RErdYq/PByog==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1376,21 +842,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.826.0.tgz",
-      "integrity": "sha512-N+IVZBh+yx/9GbMZTKO/gErBi/FYZQtcFRItoLbY+6WU+0cSWyZYfkoeOxHmQV3iX9k65oljERIWUmL9x6OSQg==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.957.0.tgz",
+      "integrity": "sha512-8dS55QHRxXgJlHkEYaCGZIhieCs9NU1HU1BcqQ4RfUdSsfRdxxktqUKgCnBnOOn0oD3PPA8cQOCAVgIyRb3Rfw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.2",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-stream": "^4.5.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1398,24 +864,45 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.826.0.tgz",
-      "integrity": "sha512-g7n+qSklq/Lzjxe2Ke5QFNCgYn26a3ydZnbFIk8QqYin4pzG+qiunaqJjpV3c/EeHMlfK8bBc7MXAylKzGRccQ==",
+      "version": "3.962.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.962.0.tgz",
+      "integrity": "sha512-h0kVnXLW2d3nxbcrR/Pfg3W/+YoCguasWz7/3nYzVqmdKarGrpJzaFdoZtLgvDSZ8VgWUC4lWOTcsDMV0UNqUQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.826.0",
-        "@aws-sdk/credential-provider-web-identity": "3.826.0",
-        "@aws-sdk/nested-clients": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/credential-provider-env": "3.957.0",
+        "@aws-sdk/credential-provider-http": "3.957.0",
+        "@aws-sdk/credential-provider-login": "3.962.0",
+        "@aws-sdk/credential-provider-process": "3.957.0",
+        "@aws-sdk/credential-provider-sso": "3.958.0",
+        "@aws-sdk/credential-provider-web-identity": "3.958.0",
+        "@aws-sdk/nested-clients": "3.958.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/credential-provider-imds": "^4.2.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.962.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.962.0.tgz",
+      "integrity": "sha512-kHYH6Av2UifG3mPkpPUNRh/PuX6adaAcpmsclJdHdxlixMCRdh8GNeEihq480DC0GmfqdpoSf1w2CLmLLPIS6w==",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/nested-clients": "3.958.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1423,23 +910,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.826.0.tgz",
-      "integrity": "sha512-UfIJXxHjmSxH6bea00HBPLkjNI2D04enQA/xNLZvB+4xtzt1/gYdCis1P4/73f5aGVVVB4/zQMobBbnjkrmbQw==",
+      "version": "3.962.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.962.0.tgz",
+      "integrity": "sha512-CS78NsWRxLa+nWqeWBEYMZTLacMFIXs1C5WJuM9kD05LLiWL32ksljoPsvNN24Bc7rCSQIIMx/U3KGvkDVZMVg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-ini": "3.826.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.826.0",
-        "@aws-sdk/credential-provider-web-identity": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/credential-provider-env": "3.957.0",
+        "@aws-sdk/credential-provider-http": "3.957.0",
+        "@aws-sdk/credential-provider-ini": "3.962.0",
+        "@aws-sdk/credential-provider-process": "3.957.0",
+        "@aws-sdk/credential-provider-sso": "3.958.0",
+        "@aws-sdk/credential-provider-web-identity": "3.958.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/credential-provider-imds": "^4.2.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1447,17 +934,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.826.0.tgz",
-      "integrity": "sha512-kURrc4amu3NLtw1yZw7EoLNEVhmOMRUTs+chaNcmS+ERm3yK0nKjaJzmKahmwlTQTSl3wJ8jjK7x962VPo+zWw==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.957.0.tgz",
+      "integrity": "sha512-/KIz9kadwbeLy6SKvT79W81Y+hb/8LMDyeloA2zhouE28hmne+hLn0wNCQXAAupFFlYOAtZR2NTBs7HBAReJlg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1465,19 +952,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.826.0.tgz",
-      "integrity": "sha512-F19J3zcfoom6OnQ0MyAtvduVKQXPgkz9i5ExSO01J2CzjbyMhCDA99qAjHYe+LwhW+W7P/jzBPd0+uOQ2Nhh9Q==",
+      "version": "3.958.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.958.0.tgz",
+      "integrity": "sha512-CBYHJ5ufp8HC4q+o7IJejCUctJXWaksgpmoFpXerbjAso7/Fg7LLUu9inXVOxlHKLlvYekDXjIUBXDJS2WYdgg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.826.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/token-providers": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/client-sso": "3.958.0",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/token-providers": "3.958.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1485,17 +972,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.826.0.tgz",
-      "integrity": "sha512-o27GZ6Hy7qhuvMFVUL2eFEpBzf33Jaa/x3u3SHwU0nL7ko7jmbpeF0x4+wmagpI9X2IvVlUxIs0VaQ3YayPLEA==",
+      "version": "3.958.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.958.0.tgz",
+      "integrity": "sha512-dgnvwjMq5Y66WozzUzxNkCFap+umHUtqMMKlr8z/vl9NYMLem/WUbWNpFFOVFWquXikc+ewtpBMR4KEDXfZ+KA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/nested-clients": "3.958.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1503,306 +991,62 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.830.0.tgz",
-      "integrity": "sha512-Q16Yf52L9QWsRhaaG/Q6eUkUWGUrbKTM2ba8at8ZZ8tsGaKO5pYgXUTErxB1bin11S6JszinbLqUf9G9oUExxA==",
+      "version": "3.962.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.962.0.tgz",
+      "integrity": "sha512-KIFu4zkMxJ9TeBm/TWv64W9en5fSP/pPWxm3tkFMleEmyotWmC2xkihZZYcHKgLhezA3fyZxTVz2v++6DpO76A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.830.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.830.0",
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-ini": "3.830.0",
-        "@aws-sdk/credential-provider-node": "3.830.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.830.0",
-        "@aws-sdk/credential-provider-web-identity": "3.830.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/client-cognito-identity": "3.962.0",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.962.0",
+        "@aws-sdk/credential-provider-env": "3.957.0",
+        "@aws-sdk/credential-provider-http": "3.957.0",
+        "@aws-sdk/credential-provider-ini": "3.962.0",
+        "@aws-sdk/credential-provider-login": "3.962.0",
+        "@aws-sdk/credential-provider-node": "3.962.0",
+        "@aws-sdk/credential-provider-process": "3.957.0",
+        "@aws-sdk/credential-provider-sso": "3.958.0",
+        "@aws-sdk/credential-provider-web-identity": "3.958.0",
+        "@aws-sdk/nested-clients": "3.958.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/credential-provider-imds": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.830.0.tgz",
-      "integrity": "sha512-5zCEpfI+zwX2SIa258L+TItNbBoAvQQ6w74qdFM6YJufQ1F9tvwjTX8T+eSTT9nsFIvfYnUaGalWwJVfmJUgVQ==",
-      "dev": true,
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.957.0.tgz",
+      "integrity": "sha512-xds1mkwEGzXrNy/gT6/ehaJ+cbYn/QM7AkdwNrO1NBlwJVLo3imO6hOnOQ/0KWG2ck1dbKv9H9f2hka67bAzEA==",
+      "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.830.0.tgz",
-      "integrity": "sha512-zeQenzvh8JRY5nULd8izdjVGoCM1tgsVVsrLSwDkHxZTTW0hW/bmOmXfvdaE0wDdomXW7m2CkQDSmP7XdvNXZg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.830.0",
-        "@aws-sdk/credential-provider-web-identity": "3.830.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.830.0.tgz",
-      "integrity": "sha512-X/2LrTgwtK1pkWrvofxQBI8VTi6QVLtSMpsKKPPnJQ0vgqC0e4czSIs3ZxiEsOkCBaQ2usXSiKyh0ccsQ6k2OA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-ini": "3.830.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.830.0",
-        "@aws-sdk/credential-provider-web-identity": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.830.0.tgz",
-      "integrity": "sha512-+VdRpZmfekzpySqZikAKx6l5ndnLGluioIgUG4ZznrButgFD/iogzFtGmBDFB3ZLViX1l4pMXru0zFwJEZT21Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.830.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/token-providers": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.830.0.tgz",
-      "integrity": "sha512-hPYrKsZeeOdLROJ59T6Y8yZ0iwC/60L3qhZXjapBFjbqBtMaQiMTI645K6xVXBioA6vxXq7B4aLOhYqk6Fy/Ww==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.828.0.tgz",
-      "integrity": "sha512-nixvI/SETXRdmrVab4D9LvXT3lrXkwAWGWk2GVvQvzlqN1/M/RfClj+o37Sn4FqRkGH9o9g7Fqb1YqZ4mqDAtA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@smithy/core": "^3.5.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.830.0.tgz",
-      "integrity": "sha512-5N5YTlBr1vtxf7+t+UaIQ625KEAmm7fY9o1e3MgGOi/paBoI0+axr3ud24qLIy0NSzFlAHEaxUSWxcERNjIoZw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/token-providers": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.830.0.tgz",
-      "integrity": "sha512-aJ4guFwj92nV9D+EgJPaCFKK0I3y2uMchiDfh69Zqnmwfxxxfxat6F79VA7PS0BdbjRfhLbn+Ghjftnomu2c1g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.828.0.tgz",
-      "integrity": "sha512-RvKch111SblqdkPzg3oCIdlGxlQs+k+P7Etory9FmxPHyPDvsP1j1c74PmgYqtzzMWmoXTjd+c9naUHh9xG8xg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-endpoints": "^3.0.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.828.0.tgz",
-      "integrity": "sha512-LdN6fTBzTlQmc8O8f1wiZN0qF3yBWVGis7NwpWK7FUEzP9bEZRxYfIkV9oV9zpt6iNRze1SedK3JQVB/udxBoA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/core": "3.957.0",
+        "@smithy/core": "^3.20.0",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
+        "@aws-sdk/client-dynamodb": "^3.957.0"
       }
     },
     "node_modules/@aws-sdk/endpoint-cache": {
-      "version": "3.804.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.804.0.tgz",
-      "integrity": "sha512-TQVDkA/lV6ua75ELZaichMzlp6x7tDa1bqdy/+0ZftmODPtKXuOOEcJxmdN7Ui/YRo1gkRz2D9txYy7IlNg1Og==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.957.0.tgz",
+      "integrity": "sha512-QxvFejXYYBZp/GBfT7B15gvmvuq+0f2U8RPHqArf5IqBi51ZyBqUD805tQ8TlsVrlLoi+Z4fEFw4HEM5pGvPUg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1814,38 +1058,38 @@
       }
     },
     "node_modules/@aws-sdk/lib-dynamodb": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.826.0.tgz",
-      "integrity": "sha512-KFHccreS1XY8geyz4plsH+DR5SXEh2jVe3+bguHPjE1XIyz6k02IUXjlpWlaL14kkAVmQ27XNrGHnnpshrbIag==",
+      "version": "3.962.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.962.0.tgz",
+      "integrity": "sha512-aUUqAO9GHHXEucuZgQiA/1rf8Q4UnitbNs3Y7y72ic8PmTrHAa64tVyd1Rlwwj27opy9BSdYRaUuMfAjSM1hXQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/util-dynamodb": "3.826.0",
-        "@smithy/core": "^3.5.3",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/util-dynamodb": "3.962.0",
+        "@smithy/core": "^3.20.0",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.826.0"
+        "@aws-sdk/client-dynamodb": "^3.962.0"
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.821.0.tgz",
-      "integrity": "sha512-8EguERzvpzTN2WrPaspK/F9GSkAzBQbecgIaCL49rJWKAso+ewmVVPnrXGzbeGVXTk4G0XuWSjt8wqUzZyt7wQ==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.957.0.tgz",
+      "integrity": "sha512-MJjlw4mVJNTyR5dW6wpzKLRzFPIYAMA8qUWqgG4hGscmm4GFHvWVJ9mhhdpDu7Ie4Uaikmzfy0C4xzZ+lkf1+w==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/endpoint-cache": "3.804.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/endpoint-cache": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1853,15 +1097,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.821.0.tgz",
-      "integrity": "sha512-xSMR+sopSeWGx5/4pAGhhfMvGBHioVBbqGvDs6pG64xfNwM5vq5s5v6D04e2i+uSTj4qGa71dLUs5I0UzAK3sw==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.957.0.tgz",
+      "integrity": "sha512-BBgKawVyfQZglEkNTuBBdC3azlyqNXsvvN4jPkWAiNYcY0x1BasaJFl+7u/HisfULstryweJq/dAvIZIxzlZaA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1869,14 +1113,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.821.0.tgz",
-      "integrity": "sha512-0cvI0ipf2tGx7fXYEEN5fBeZDz2RnHyb9xftSgUsEq7NBxjV0yTZfLJw6Za5rjE6snC80dRN8+bTNR1tuG89zA==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.957.0.tgz",
+      "integrity": "sha512-w1qfKrSKHf9b5a8O76yQ1t69u6NWuBjr5kBX+jRWFx/5mu6RLpqERXRpVJxfosbep7k3B+DSB5tZMZ82GKcJtQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1884,15 +1128,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.821.0.tgz",
-      "integrity": "sha512-efmaifbhBoqKG3bAoEfDdcM8hn1psF+4qa7ykWuYmfmah59JBeqHLfz5W9m9JoTwoKPkFcVLWZxnyZzAnVBOIg==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.957.0.tgz",
+      "integrity": "sha512-D2H/WoxhAZNYX+IjkKTdOhOkWQaK0jjJrDBj56hKjU5c9ltQiaX/1PqJ4dfjHntEshJfu0w+E6XJ+/6A6ILBBA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/types": "3.957.0",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1900,18 +1145,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.826.0.tgz",
-      "integrity": "sha512-j404+EcfBbtTlAhyObjXbdKwwDXO1pCxHvR5Fw8FXNvp/H330j6YnXgs3SJ6d3bZUwUJ/ztPx2S5AlBbLVLDFw==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.957.0.tgz",
+      "integrity": "sha512-50vcHu96XakQnIvlKJ1UoltrFODjsq2KvtTgHiPFteUS884lQnK5VC/8xd1Msz/1ONpLMzdCVproCQqhDTtMPQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.821.0",
-        "@smithy/core": "^3.5.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@smithy/core": "^3.20.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1919,49 +1164,49 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.826.0.tgz",
-      "integrity": "sha512-p7olPq0uTtHqGuXI1GSc/gzKDvV55PMbLtnmupEDfnY9SoRu+QatbWQ6da9sI1lhOcNmRMgiNQBXFzaUFrG+SQ==",
+      "version": "3.958.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.958.0.tgz",
+      "integrity": "sha512-/KuCcS8b5TpQXkYOrPLYytrgxBhv81+5pChkOlhegbeHttjM69pyUpQVJqyfDM/A7wPLnDrzCAnk4zaAOkY0Nw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.826.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.821.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.826.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.957.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1969,17 +1214,16 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.821.0.tgz",
-      "integrity": "sha512-t8og+lRCIIy5nlId0bScNpCkif8sc0LhmtaKsbm0ZPm3sCa/WhCbSZibjbZ28FNjVCV+p0D9RYZx0VDDbtWyjw==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.957.0.tgz",
+      "integrity": "sha512-V8iY3blh8l2iaOqXWW88HbkY5jDoWjH56jonprG/cpyqqCnprvpMUZWPWYJoI8rHRf2bqzZeql1slxG6EnKI7A==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1987,18 +1231,18 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.826.0.tgz",
-      "integrity": "sha512-iCOcVAqGPSHtQL8ZBXifZMEcHyUl9wJ8HvLZ5l1ohA/3ZNP+dqEPGi7jfhR5jZKs+xyp2jxByFqfil9PjI9c5A==",
+      "version": "3.958.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.958.0.tgz",
+      "integrity": "sha512-UCj7lQXODduD1myNJQkV+LYcGYJ9iiMggR8ow8Hva1g3A/Na5imNXzz6O67k7DAee0TYpy+gkNw+SizC6min8Q==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/core": "3.957.0",
+        "@aws-sdk/nested-clients": "3.958.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2006,13 +1250,13 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.821.0.tgz",
-      "integrity": "sha512-Znroqdai1a90TlxGaJ+FK1lwC0fHpo97Xjsp5UKGR5JODYm7f9+/fF17ebO1KdoBr/Rm0UIFiF5VmI8ts9F1eA==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.957.0.tgz",
+      "integrity": "sha512-wzWC2Nrt859ABk6UCAVY/WYEbAd7FjkdrQL6m24+tfmWYDNRByTJ9uOgU/kw9zqLCAwb//CPvrJdhqjTznWXAg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2020,9 +1264,9 @@
       }
     },
     "node_modules/@aws-sdk/util-dynamodb": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.826.0.tgz",
-      "integrity": "sha512-4zsbpJ9wEnDDvCTrhPCc/iLkn8Bf0+ux4iK39b4cX11sSPVtwTUnpnGHyilApKWaxBKwNIJHicwskwORxqR2mw==",
+      "version": "3.962.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.962.0.tgz",
+      "integrity": "sha512-hv2Imj8R8AcMmntWq2/oxNs0CPQojFpgvyR5UalXSY3hIhcEHrWADimG2OwkW7J1Y9eKx/3NKfFpqsmDogbJMg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2032,19 +1276,20 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.826.0"
+        "@aws-sdk/client-dynamodb": "^3.962.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.821.0.tgz",
-      "integrity": "sha512-Uknt/zUZnLE76zaAAPEayOeF5/4IZ2puTFXvcSCWHsi9m3tqbb9UozlnlVqvCZLCRWfQryZQoG2W4XSS3qgk5A==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.957.0.tgz",
+      "integrity": "sha512-xwF9K24mZSxcxKS3UKQFeX/dPYkEps9wF1b+MGON7EvnbcucrJGyQyK1v1xFPn1aqXkBTFi+SZaMRx5E5YCVFw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-endpoints": "^3.0.6",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-endpoints": "^3.2.7",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2065,29 +1310,29 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.821.0.tgz",
-      "integrity": "sha512-irWZHyM0Jr1xhC+38OuZ7JB6OXMLPZlj48thElpsO1ZSLRkLZx5+I7VV6k3sp2yZ7BYbKz/G2ojSv4wdm7XTLw==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.957.0.tgz",
+      "integrity": "sha512-exueuwxef0lUJRnGaVkNSC674eAiWU07ORhxBnevFFZEKisln+09Qrtw823iyv5I1N8T+wKfh95xvtWQrNKNQw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/types": "^4.11.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.826.0.tgz",
-      "integrity": "sha512-wHw6bZQWIMcFF/8r03aY9Itp6JLBYY4absGGhCDK1dc3tPEfi8NVSdb05a/Oz+g4TVaDdxLo0OQ/OKMS1DFRHQ==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.957.0.tgz",
+      "integrity": "sha512-ycbYCwqXk4gJGp0Oxkzf2KBeeGBdTxz559D41NJP8FlzSej1Gh7Rk40Zo6AyTfsNWkrl/kVi1t937OIzC5t+9Q==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/middleware-user-agent": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2103,15 +1348,26 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.821.0.tgz",
-      "integrity": "sha512-DIIotRnefVL6DiaHtO6/21DhJ4JZnnIwdNbpwiAhdt/AVbttcE4yw925gsjur0OGv5BTYXQXU3YnANBYnZjuQA==",
+      "version": "3.957.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.957.0.tgz",
+      "integrity": "sha512-Ai5iiQqS8kJ5PjzMhWcLKN0G2yasAkvpnPlq2EnqlIMdB48HsizElt62qcktdxp4neRMyGkFq4NzgmDbXnhRiA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.11.0",
+        "fast-xml-parser": "5.2.5",
         "tslib": "^2.6.2"
       },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
+      "integrity": "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==",
+      "inBundle": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -2147,6 +1403,7 @@
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2627,9 +1884,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
@@ -2644,9 +1901,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
@@ -2661,9 +1918,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
@@ -2678,9 +1935,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
@@ -2695,9 +1952,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
@@ -2712,9 +1969,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
@@ -2729,9 +1986,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
@@ -2746,9 +2003,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
@@ -2763,9 +2020,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
@@ -2780,9 +2037,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
@@ -2797,9 +2054,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
@@ -2814,9 +2071,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
@@ -2831,9 +2088,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
@@ -2848,9 +2105,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
@@ -2865,9 +2122,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
@@ -2882,9 +2139,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
@@ -2899,9 +2156,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
@@ -2916,9 +2173,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "cpu": [
         "arm64"
       ],
@@ -2933,9 +2190,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
@@ -2950,9 +2207,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
       "cpu": [
         "arm64"
       ],
@@ -2967,9 +2224,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
@@ -2983,10 +2240,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
@@ -3001,9 +2275,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
@@ -3018,9 +2292,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
@@ -3035,9 +2309,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
@@ -3051,107 +2325,27 @@
         "node": ">=18"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+        "node": "20 || >=22"
       }
     },
-    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
+        "@isaacs/balanced-match": "^4.0.1"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -3554,9 +2748,9 @@
       }
     },
     "node_modules/@jsii/spec": {
-      "version": "1.112.0",
-      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.112.0.tgz",
-      "integrity": "sha512-O6peIhjjGkIQpbKUMHTNJHMuyqd6EXqWlxnBKpoBoUwDz18HXxt/SwUvnovYCELjgxOUMCdO5Y4/YjeABvatUw==",
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.125.0.tgz",
+      "integrity": "sha512-FneFGrzBMAUjLM1Z4LY3VuWhUrBWUgfrPYLsjnC11HwcMgE1LvVi26QIuTKvV0KWCStIJu4N2TkOEc82b0hbUQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3572,7 +2766,6 @@
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -3587,7 +2780,6 @@
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -3598,7 +2790,6 @@
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -3608,16 +2799,16 @@
       }
     },
     "node_modules/@redocly/ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-EDtsGZS964mf9zAUXAl9Ew16eYbeyAFWhsPr0fX6oaJxgd8rApYlPBf0joyhnUHz88WxrigyFtTaqqzXNzPgqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js-replace": "^1.0.1"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -3632,9 +2823,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.34.3",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.3.tgz",
-      "integrity": "sha512-3arRdUp1fNx55itnjKiUhO6t4Mf91TsrTIYINDNLAZPS0TPd5YpiXRctwjel0qqWoOOhjA34cZ3m4dksLDFUYg==",
+      "version": "1.34.6",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.6.tgz",
+      "integrity": "sha512-2+O+riuIUgVSuLl3Lyh5AplWZyVMNuG2F98/o6NrutKJfW4/GTZdPpZlIphS0HGgcOHgmWcCSHj+dWFlZaGSHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3661,9 +2852,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3671,9 +2862,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3753,13 +2944,13 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.4.tgz",
-      "integrity": "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.7.tgz",
+      "integrity": "sha512-rzMY6CaKx2qxrbYbqjXWS0plqEy7LOdKHS0bg4ixJ6aoGDPNUcLWk/FRNuCILh7GKLG9TFUXYYeQQldMBBwuyw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3767,16 +2958,17 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.4.tgz",
-      "integrity": "sha512-prmU+rDddxHOH0oNcwemL+SwnzcG65sBF2yXRO7aeXIn/xTlq2pX7JLVbkBnVLowHLg4/OL4+jBmv9hVrVGS+w==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.5.tgz",
+      "integrity": "sha512-HAGoUAFYsUkoSckuKbCPayECeMim8pOu+yLy1zOxt1sifzEbrsRpYa+mKcMdiHKMeiqOibyPG0sFJnmaV/OGEg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3784,20 +2976,21 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.5.3.tgz",
-      "integrity": "sha512-xa5byV9fEguZNofCclv6v9ra0FYh5FATQW/da7FQUVTic94DfrN/NvmKZjrMyzbpqfot9ZjBaO8U1UeTbmSLuA==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.0.tgz",
+      "integrity": "sha512-WsSHCPq/neD5G/MkK4csLI5Y5Pkd9c1NMfpYEKeghSGaD4Ja1qLIohRQf2D5c1Uy5aXp76DeKHkzWZ9KAlHroQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-stream": "^4.2.2",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-stream": "^4.5.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3805,16 +2998,16 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.6.tgz",
-      "integrity": "sha512-hKMWcANhUiNbCJouYkZ9V3+/Qf9pteR1dnwgdyzR09R4ODEYx8BbUysHwRSyex4rZ9zapddZhLFTnT4ZijR4pw==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.7.tgz",
+      "integrity": "sha512-CmduWdCiILCRNbQWFR0OcZlUPVtyE49Sr8yYL0rZQ4D/wKxiNzBNS/YHemvnbkIWj623fplgkexUd/c9CAKdoA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3822,15 +3015,15 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.4.tgz",
-      "integrity": "sha512-7XoWfZqWb/QoR/rAU4VSi0mWnO2vu9/ltS6JZ5ZSZv0eovLVfDfu0/AX4ub33RsJTOth3TiFWSHS5YdztvFnig==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.7.tgz",
+      "integrity": "sha512-DrpkEoM3j9cBBWhufqBwnbbn+3nf1N9FP6xuVJ+e220jbactKuQgaZwjwP5CP1t+O94brm2JgVMD2atMGX3xIQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3838,14 +3031,14 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.4.tgz",
-      "integrity": "sha512-3fb/9SYaYqbpy/z/H3yIi0bYKyAa89y6xPmIqwr2vQiUT2St+avRt8UKwsWt9fEdEasc5d/V+QjrviRaX1JRFA==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.7.tgz",
+      "integrity": "sha512-ujzPk8seYoDBmABDE5YqlhQZAXLOrtxtJLrbhHMKjBoG5b4dK4i6/mEU+6/7yXIAkqOO8sJ6YxZl+h0QQ1IJ7g==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/eventstream-serde-universal": "^4.2.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3853,13 +3046,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.1.2.tgz",
-      "integrity": "sha512-JGtambizrWP50xHgbzZI04IWU7LdI0nh/wGbqH3sJesYToMi2j/DcoElqyOcqEIG/D4tNyxgRuaqBXWE3zOFhQ==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.7.tgz",
+      "integrity": "sha512-x7BtAiIPSaNaWuzm24Q/mtSkv+BrISO/fmheiJ39PKRNH3RmH2Hph/bUKSOBOBC9unqfIYDhKTHwpyZycLGPVQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3867,14 +3060,14 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.4.tgz",
-      "integrity": "sha512-RD6UwNZ5zISpOWPuhVgRz60GkSIp0dy1fuZmj4RYmqLVRtejFqQ16WmfYDdoSoAjlp1LX+FnZo+/hkdmyyGZ1w==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.7.tgz",
+      "integrity": "sha512-roySCtHC5+pQq5lK4be1fZ/WR6s/AxnPaLfCODIPArtN2du8s5Ot4mKVK3pPtijL/L654ws592JHJ1PbZFF6+A==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/eventstream-serde-universal": "^4.2.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3882,14 +3075,14 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.4.tgz",
-      "integrity": "sha512-UeJpOmLGhq1SLox79QWw/0n2PFX+oPRE1ZyRMxPIaFEfCqWaqpB7BU9C8kpPOGEhLF7AwEqfFbtwNxGy4ReENA==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.7.tgz",
+      "integrity": "sha512-QVD+g3+icFkThoy4r8wVFZMsIP08taHVKjE6Jpmz8h5CgX/kk6pTODq5cht0OMtcapUx+xrPzUTQdA+TmO0m1g==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/eventstream-codec": "^4.2.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3897,16 +3090,16 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.4.tgz",
-      "integrity": "sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.8.tgz",
+      "integrity": "sha512-h/Fi+o7mti4n8wx1SR6UHWLaakwHRx29sizvp8OOm7iqwKGFneT06GCSFhml6Bha5BT6ot5pj3CYZnCHhGC2Rg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/querystring-builder": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/querystring-builder": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3914,15 +3107,15 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.4.tgz",
-      "integrity": "sha512-qnbTPUhCVnCgBp4z4BUJUhOEkVwxiEi1cyFM+Zj6o+aY8OFGxUQleKWq8ltgp3dujuhXojIvJWdoqpm6dVO3lQ==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.7.tgz",
+      "integrity": "sha512-PU/JWLTBCV1c8FtB8tEFnY4eV1tSfBc7bDBADHfn1K+uRbPgSJ9jnJp0hyjiFN2PMdPzxsf1Fdu0eo9fJ760Xw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3930,13 +3123,13 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.4.tgz",
-      "integrity": "sha512-bNYMi7WKTJHu0gn26wg8OscncTt1t2b8KcsZxvOv56XA6cyXtOAAAaNP7+m45xfppXfOatXF3Sb1MNsLUgVLTw==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.7.tgz",
+      "integrity": "sha512-ncvgCr9a15nPlkhIUx3CU4d7E7WEuVJOV7fS7nnK2hLtPK9tYRBkMHQbhXU1VvvKeBm/O0x26OEoBq+ngFpOEQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3944,9 +3137,9 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
-      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3957,14 +3150,14 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.4.tgz",
-      "integrity": "sha512-F7gDyfI2BB1Kc+4M6rpuOLne5LOcEknH1n6UQB69qv+HucXBR1rkzXBnQTB2q46sFy1PM/zuSJOB532yc8bg3w==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.7.tgz",
+      "integrity": "sha512-GszfBfCcvt7kIbJ41LuNa5f0wvQCHhnGx/aDaZJCCT05Ld6x6U2s0xsc/0mBFONBZjQJp2U/0uSJ178OXOwbhg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3972,19 +3165,19 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.11.tgz",
-      "integrity": "sha512-zDogwtRLzKl58lVS8wPcARevFZNBOOqnmzWWxVe9XiaXU2CADFjvJ9XfNibgkOWs08sxLuSr81NrpY4mgp9OwQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.1.tgz",
+      "integrity": "sha512-gpLspUAoe6f1M6H0u4cVuFzxZBrsGZmjx2O9SigurTx4PbntYa4AJ+o0G0oGm1L2oSX6oBhcGHwrfJHup2JnJg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.5.3",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/core": "^3.20.0",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-middleware": "^4.2.7",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3992,35 +3185,35 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.12.tgz",
-      "integrity": "sha512-wvIH70c4e91NtRxdaLZF+mbLZ/HcC6yg7ySKUiufL6ESp6zJUSnJucZ309AvG9nqCFHSRB5I6T3Ez1Q9wCh0Ww==",
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.17.tgz",
+      "integrity": "sha512-MqbXK6Y9uq17h+4r0ogu/sBT6V/rdV+5NvYL7ZV444BKfQygYe8wAhDrVXagVebN6w2RE0Fm245l69mOsPGZzg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/service-error-classification": "^4.0.5",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/service-error-classification": "^4.2.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.8.tgz",
-      "integrity": "sha512-iSSl7HJoJaGyMIoNn2B7czghOVwJ9nD7TMvLhMWeSB5vt0TnEYyRRqPJu/TqW76WScaNvYYB8nRoiBHR9S1Ddw==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.8.tgz",
+      "integrity": "sha512-8rDGYen5m5+NV9eHv9ry0sqm2gI6W7mc1VSFMtn6Igo25S507/HaOX9LTHAS2/J32VXD0xSzrY0H5FJtOMS4/w==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4028,13 +3221,13 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.4.tgz",
-      "integrity": "sha512-kagK5ggDrBUCCzI93ft6DjteNSfY8Ulr83UtySog/h09lTIOAJ/xUSObutanlPT0nhoHAkpmW9V5K8oPyLh+QA==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.7.tgz",
+      "integrity": "sha512-bsOT0rJ+HHlZd9crHoS37mt8qRRN/h9jRve1SXUhVbkRzu0QaNYZp1i1jha4n098tsvROjcwfLlfvcFuJSXEsw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4042,15 +3235,15 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.3.tgz",
-      "integrity": "sha512-HGHQr2s59qaU1lrVH6MbLlmOBxadtzTsoO4c+bF5asdgVik3I8o7JIOzoeqWc5MjVa+vD36/LWE0iXKpNqooRw==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.7.tgz",
+      "integrity": "sha512-7r58wq8sdOcrwWe+klL9y3bc4GW1gnlfnFOuL7CXa7UzfhzhxKuzNdtqgzmTV+53lEp9NXh5hY/S4UgjLOzPfw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4058,16 +3251,16 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.6.tgz",
-      "integrity": "sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.7.tgz",
+      "integrity": "sha512-NELpdmBOO6EpZtWgQiHjoShs1kmweaiNuETUpuup+cmm/xJYjT4eUjfhrXRP4jCOaAsS3c3yPsP3B+K+/fyPCQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/querystring-builder": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/abort-controller": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/querystring-builder": "^4.2.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4075,13 +3268,13 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.4.tgz",
-      "integrity": "sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.7.tgz",
+      "integrity": "sha512-jmNYKe9MGGPoSl/D7JDDs1C8b3dC8f/w78LbaVfoTtWy4xAd5dfjaFG9c9PWPihY4ggMQNQSMtzU77CNgAJwmA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4089,13 +3282,13 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.2.tgz",
-      "integrity": "sha512-rOG5cNLBXovxIrICSBm95dLqzfvxjEmuZx4KK3hWwPFHGdW3lxY0fZNXfv2zebfRO7sJZ5pKJYHScsqopeIWtQ==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
+      "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4103,14 +3296,14 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.4.tgz",
-      "integrity": "sha512-SwREZcDnEYoh9tLNgMbpop+UTGq44Hl9tdj3rf+yeLcfH7+J8OXEBaMc2kDxtyRHu8BhSg9ADEx0gFHvpJgU8w==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.7.tgz",
+      "integrity": "sha512-eKONSywHZxK4tBxe2lXEysh8wbBdvDWiA+RIuaxZSgCMmA0zMgoDpGLJhnyj+c0leOQprVnXOmcB4m+W9Rw7sg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-uri-escape": "^4.0.0",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-uri-escape": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4118,13 +3311,13 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.4.tgz",
-      "integrity": "sha512-6yZf53i/qB8gRHH/l2ZwUG5xgkPgQF15/KxH0DdXMDHjesA9MeZje/853ifkSY0x4m5S+dfDZ+c4x439PF0M2w==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.7.tgz",
+      "integrity": "sha512-3X5ZvzUHmlSTHAXFlswrS6EGt8fMSIxX/c3Rm1Pni3+wYWB6cjGocmRIoqcQF9nU5OgGmL0u7l9m44tSUpfj9w==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4132,26 +3325,26 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.5.tgz",
-      "integrity": "sha512-LvcfhrnCBvCmTee81pRlh1F39yTS/+kYleVeLCwNtkY8wtGg8V/ca9rbZZvYIl8OjlMtL6KIjaiL/lgVqHD2nA==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.7.tgz",
+      "integrity": "sha512-YB7oCbukqEb2Dlh3340/8g8vNGbs/QsNNRms+gv3N2AtZz9/1vSBx6/6tpwQpZMEJFs7Uq8h4mmOn48ZZ72MkA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1"
+        "@smithy/types": "^4.11.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.4.tgz",
-      "integrity": "sha512-63X0260LoFBjrHifPDs+nM9tV0VMkOTl4JRMYNuKh/f5PauSjowTfvF3LogfkWdcPoxsA9UjqEOgjeYIbhb7Nw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.2.tgz",
+      "integrity": "sha512-M7iUUff/KwfNunmrgtqBfvZSzh3bmFgv/j/t1Y1dQ+8dNo34br1cqVEqy6v0mYEgi0DkGO7Xig0AnuOaEGVlcg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4159,19 +3352,19 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.2.tgz",
-      "integrity": "sha512-d3+U/VpX7a60seHziWnVZOHuEgJlclufjkS6zhXvxcJgkJq4UWdH5eOBLzHRMx6gXjsdT9h6lfpmLzbrdupHgQ==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.7.tgz",
+      "integrity": "sha512-9oNUlqBlFZFOSdxgImA6X5GFuzE7V2H7VG/7E70cdLhidFbdtvxxt81EHgykGK5vq5D3FafH//X+Oy31j3CKOg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4179,18 +3372,18 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.3.tgz",
-      "integrity": "sha512-xxzNYgA0HD6ETCe5QJubsxP0hQH3QK3kbpJz3QrosBCuIWyEXLR/CO5hFb2OeawEKUxMNhz3a1nuJNN2np2RMA==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.2.tgz",
+      "integrity": "sha512-D5z79xQWpgrGpAHb054Fn2CCTQZpog7JELbVQ6XAvXs5MNKWf28U9gzSBlJkOyMl9LA1TZEjRtwvGXfP0Sl90g==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.5.3",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.2",
+        "@smithy/core": "^3.20.0",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-stream": "^4.5.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4198,9 +3391,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.1.tgz",
-      "integrity": "sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.11.0.tgz",
+      "integrity": "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4211,14 +3404,14 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.4.tgz",
-      "integrity": "sha512-eMkc144MuN7B0TDA4U2fKs+BqczVbk3W+qIvcoCY6D1JY3hnAdCuhCZODC+GAeaxj0p6Jroz4+XMUn3PCxQQeQ==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.7.tgz",
+      "integrity": "sha512-/RLtVsRV4uY3qPWhBDsjwahAtt3x2IsMGnP5W1b2VZIe+qgCqkLxI1UOHDZp1Q1QSOrdOR32MF3Ph2JfWT1VHg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/querystring-parser": "^4.2.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4226,14 +3419,14 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
-      "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4241,9 +3434,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
-      "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4254,9 +3447,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
-      "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4267,13 +3460,13 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
-      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/is-array-buffer": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4281,9 +3474,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
-      "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4294,16 +3487,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.19.tgz",
-      "integrity": "sha512-mvLMh87xSmQrV5XqnUYEPoiFFeEGYeAKIDDKdhE2ahqitm8OHM3aSvhqL6rrK6wm1brIk90JhxDf5lf2hbrLbQ==",
+      "version": "4.3.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.16.tgz",
+      "integrity": "sha512-/eiSP3mzY3TsvUOYMeL4EqUX6fgUOj2eUOU4rMMgVbq67TiRLyxT7Xsjxq0bW3OwuzK009qOwF0L2OgJqperAQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "bowser": "^2.11.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4311,18 +3503,18 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.19.tgz",
-      "integrity": "sha512-8tYnx+LUfj6m+zkUUIrIQJxPM1xVxfRBvoGHua7R/i6qAxOMjqR6CpEpDwKoIs1o0+hOjGvkKE23CafKL0vJ9w==",
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.19.tgz",
+      "integrity": "sha512-3a4+4mhf6VycEJyHIQLypRbiwG6aJvbQAeRAVXydMmfweEPnLLabRbdyo/Pjw8Rew9vjsh5WCdhmDaHkQnhhhA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/credential-provider-imds": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4330,14 +3522,14 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.6.tgz",
-      "integrity": "sha512-YARl3tFL3WgPuLzljRUnrS2ngLiUtkwhQtj8PAL13XZSyUiNLQxwG3fBBq3QXFqGFUXepIN73pINp3y8c2nBmA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.7.tgz",
+      "integrity": "sha512-s4ILhyAvVqhMDYREeTS68R43B1V5aenV5q/V1QpRQJkCXib5BPRo4s7uNdzGtIKxaPHCfU/8YkvPAEvTpxgspg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4345,9 +3537,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
-      "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4358,13 +3550,13 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.4.tgz",
-      "integrity": "sha512-9MLKmkBmf4PRb0ONJikCbCwORACcil6gUWojwARCClT7RmLzF04hUR4WdRprIXal7XVyrddadYNfp2eF3nrvtQ==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.7.tgz",
+      "integrity": "sha512-i1IkpbOae6NvIKsEeLLM9/2q4X+M90KV3oCFgWQI4q0Qz+yUZvsr+gZPdAEAtFhWQhAHpTsJO8DRJPuwVyln+w==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4372,14 +3564,14 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.5.tgz",
-      "integrity": "sha512-V7MSjVDTlEt/plmOFBn1762Dyu5uqMrV2Pl2X0dYk4XvWfdWJNe9Bs5Bzb56wkCuiWjSfClVMGcsuKrGj7S/yg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.7.tgz",
+      "integrity": "sha512-SvDdsQyF5CIASa4EYVT02LukPHVzAgUA4kMAuZ97QJc2BpAqZfA4PINB8/KOoCXEw9tsuv/jQjMeaHFvxdLNGg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.0.5",
-        "@smithy/types": "^4.3.1",
+        "@smithy/service-error-classification": "^4.2.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4387,19 +3579,19 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.2.tgz",
-      "integrity": "sha512-aI+GLi7MJoVxg24/3J1ipwLoYzgkB4kUfogZfnslcYlynj3xsQ0e7vk4TnTro9hhsS5PvX1mwmkRqqHQjwcU7w==",
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.8.tgz",
+      "integrity": "sha512-ZnnBhTapjM0YPGUSmOs0Mcg/Gg87k503qG4zU2v/+Js2Gu+daKOJMeqcQns8ajepY8tgzzfYxl6kQyZKml6O2w==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4407,9 +3599,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
-      "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4420,13 +3612,13 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
-      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4434,14 +3626,27 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.5.tgz",
-      "integrity": "sha512-4QvC49HTteI1gfemu0I1syWovJgPvGn7CVUoN9ZFkdvr/cCFkrEL7qNCdx/2eICqDWEGnnr68oMdSIPCLAriSQ==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.7.tgz",
+      "integrity": "sha512-vHJFXi9b7kUEpHWUCY3Twl+9NPOZvQ0SAi+Ewtn48mbiJk4JY9MZmKQjGB4SCvVb9WPiSphZJYY6RIbs+grrzw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/abort-controller": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4477,9 +3682,9 @@
       "license": "MIT"
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.149",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.149.tgz",
-      "integrity": "sha512-NXSZIhfJjnXqJgtS7IwutqIF/SOy1Wz5Px4gUY1RWITp3AYTyuJS4xaXr/bIJY1v15XMzrJ5soGnPM+7uigZjA==",
+      "version": "8.10.159",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.159.tgz",
+      "integrity": "sha512-SAP22WSGNN12OQ8PlCzGzRCZ7QDCwI85dQZbmpz7+mAk+L7j+wI7qnvmdKh+o7A5LaOp6QnOZ2NJphAZQTTHQg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4611,13 +3816,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.7.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.9.tgz",
-      "integrity": "sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg==",
+      "version": "22.15.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.32.tgz",
+      "integrity": "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/sinon": {
@@ -4642,13 +3848,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -4732,7 +3931,6 @@
       "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.6"
       }
@@ -4764,9 +3962,9 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4936,13 +4134,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/async-each": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.6.tgz",
@@ -4970,25 +4161,25 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1014.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1014.0.tgz",
-      "integrity": "sha512-es101rtRAClix9BncNL54iW90MiOyRv4iCC5tv/firGDnidS6pPinuK0IIFt0RO6w0+3heRxWBXg8HY+f9877w==",
+      "version": "2.1100.2",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1100.2.tgz",
+      "integrity": "sha512-PK80VEunZGpGW3+66EbPUpoKZKxsK7/BBR3X2qqtgk5wrSVJn+rq3Rwlih5lCD223rpf2RXAnC5weGHdEtgSuA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.0.0"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.194.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.194.0.tgz",
-      "integrity": "sha512-v12l31Rx/BDjXEyMsfSmDRsjZu0AzHMoRHDqbcSzDcvSYHjnEW/nuFR0R1+tat9nEX8h54GDctduL6pFcJ8xUg==",
+      "version": "2.233.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.233.0.tgz",
+      "integrity": "sha512-rBOzIA8TGC5eB8TyVIvckAVlX7a0/gVPE634FguhSee9RFaovjgc5+IixGyyLJhu3lLsMSjqDoqTJg2ab+p8ng==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -5005,23 +4196,23 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.229",
+        "@aws-cdk/asset-awscli-v1": "2.2.242",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^41.0.0",
+        "@aws-cdk/cloud-assembly-schema": "^48.20.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.0",
+        "fs-extra": "^11.3.2",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.7.1",
+        "semver": "^7.7.3",
         "table": "^6.9.0",
         "yaml": "1.10.2"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.0.0"
       },
       "peerDependencies": {
         "constructs": "^10.0.0"
@@ -5089,7 +4280,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5144,7 +4335,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.0.6",
+      "version": "3.1.0",
       "dev": true,
       "funding": [
         {
@@ -5160,7 +4351,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.0",
+      "version": "11.3.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5204,7 +4395,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.1.0",
+      "version": "6.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5282,7 +4473,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.1",
+      "version": "7.7.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5376,6 +4567,7 @@
       "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/sinon": "^17.0.3",
         "sinon": "^18.0.1",
@@ -5601,16 +4793,16 @@
       }
     },
     "node_modules/bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
+      "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5651,6 +4843,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -6054,9 +5247,9 @@
       }
     },
     "node_modules/codemaker": {
-      "version": "1.112.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.112.0.tgz",
-      "integrity": "sha512-9dOcSOPEDAB5y4oimdsjzi9Za6vHi7wsUeLdH2NQpP1q88D2Oo8fj6YXqM7c/97tUFqX4OaanNjQCI3K6uyn4A==",
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.125.0.tgz",
+      "integrity": "sha512-SmWZmRLE/Awxb/F99yd3VwJPomOMLFS+1CAJ8rKYZUORQQL5esqsAmQs7KxhrU6Wt1Tr2Cf7MAFPNDJbUd9SYg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6165,14 +5358,12 @@
       "license": "MIT"
     },
     "node_modules/constructs": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.0.tgz",
-      "integrity": "sha512-MIwjmrXZpM9RtwyrSD4HotDIQl8HTdIefQhU+MU1asvtSyVN3kK8kjeUOWMFb+fdyT4RX3QvvcaaPBluLEX1SA==",
+      "version": "10.4.4",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.4.tgz",
+      "integrity": "sha512-lP0qC1oViYf1cutHo9/KQ8QL637f/W29tDmv/6sy35F5zs+MD9f66nbAAIjicwc7fwyuF3rkg6PhZh4sfvWIpA==",
       "dev": true,
       "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 10.17.0"
-      }
+      "peer": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -6431,29 +5622,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.165",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.165.tgz",
@@ -6505,9 +5673,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6518,31 +5686,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.5",
-        "@esbuild/android-arm": "0.25.5",
-        "@esbuild/android-arm64": "0.25.5",
-        "@esbuild/android-x64": "0.25.5",
-        "@esbuild/darwin-arm64": "0.25.5",
-        "@esbuild/darwin-x64": "0.25.5",
-        "@esbuild/freebsd-arm64": "0.25.5",
-        "@esbuild/freebsd-x64": "0.25.5",
-        "@esbuild/linux-arm": "0.25.5",
-        "@esbuild/linux-arm64": "0.25.5",
-        "@esbuild/linux-ia32": "0.25.5",
-        "@esbuild/linux-loong64": "0.25.5",
-        "@esbuild/linux-mips64el": "0.25.5",
-        "@esbuild/linux-ppc64": "0.25.5",
-        "@esbuild/linux-riscv64": "0.25.5",
-        "@esbuild/linux-s390x": "0.25.5",
-        "@esbuild/linux-x64": "0.25.5",
-        "@esbuild/netbsd-arm64": "0.25.5",
-        "@esbuild/netbsd-x64": "0.25.5",
-        "@esbuild/openbsd-arm64": "0.25.5",
-        "@esbuild/openbsd-x64": "0.25.5",
-        "@esbuild/sunos-x64": "0.25.5",
-        "@esbuild/win32-arm64": "0.25.5",
-        "@esbuild/win32-ia32": "0.25.5",
-        "@esbuild/win32-x64": "0.25.5"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escalade": {
@@ -6745,7 +5914,6 @@
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -6763,7 +5931,6 @@
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -6777,7 +5944,6 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6788,7 +5954,6 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -6821,23 +5986,19 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^2.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -6849,7 +6010,6 @@
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -6871,39 +6031,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/filename-regex": {
       "version": "2.0.1",
@@ -6977,36 +6104,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/fragment-cache": {
@@ -7196,6 +6293,28 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -7737,47 +6856,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/jackspeak": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jake": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8386,9 +7471,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8413,23 +7498,23 @@
       }
     },
     "node_modules/jsii": {
-      "version": "5.8.12",
-      "resolved": "https://registry.npmjs.org/jsii/-/jsii-5.8.12.tgz",
-      "integrity": "sha512-4EDpRiVDJ7iXSksebwi1/k5QXKG0ZiLyXcQNBFomD57Gb0Ph7VpKHhIt53GQ2cUwigZUJ09pO4LTf3DJUivDCg==",
+      "version": "5.9.22",
+      "resolved": "https://registry.npmjs.org/jsii/-/jsii-5.9.22.tgz",
+      "integrity": "sha512-9+7/488zJPsKiwxG5Z28M977Ey7DXxhAuoplt4danGCNaGW0EXTlnRxvLWlnofoOc1reWTPf0CFRuumevnT4Cg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsii/check-node": "1.112.0",
-        "@jsii/spec": "^1.112.0",
+        "@jsii/check-node": "1.124.0",
+        "@jsii/spec": "1.124.0",
         "case": "^1.6.3",
         "chalk": "^4",
         "fast-deep-equal": "^3.1.3",
         "log4js": "^6.9.1",
-        "semver": "^7.7.2",
+        "semver": "^7.7.3",
         "semver-intersect": "^1.5.0",
         "sort-json": "^2.0.1",
         "spdx-license-list": "^6.10.0",
-        "typescript": "~5.8",
+        "typescript": "~5.9",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -8440,24 +7525,24 @@
       }
     },
     "node_modules/jsii-pacmak": {
-      "version": "1.112.0",
-      "resolved": "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.112.0.tgz",
-      "integrity": "sha512-awdZ4Hb9pc8cKp2RVhJntoppgo5KnqP8f9YCmoHPPpPCS1hB3joxpVbNS6t2PYdGt1R+j7EcO7TJdah95cxE3w==",
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.125.0.tgz",
+      "integrity": "sha512-VItspZZSZb0/h/iFM5pMVujDTKrnL8e5QMgKBymc3O+VMrUwhr95YiadjMvb5z7O2Wkit2th9RoAeWI+eJpbGw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsii/check-node": "1.112.0",
-        "@jsii/spec": "^1.112.0",
+        "@jsii/check-node": "1.125.0",
+        "@jsii/spec": "1.125.0",
         "clone": "^2.1.2",
-        "codemaker": "^1.112.0",
+        "codemaker": "^1.125.0",
         "commonmark": "^0.31.2",
         "escape-string-regexp": "^4.0.0",
         "fs-extra": "^10.1.0",
-        "jsii-reflect": "^1.112.0",
-        "semver": "^7.7.1",
+        "jsii-reflect": "^1.125.0",
+        "semver": "^7.7.2",
         "spdx-license-list": "^6.10.0",
         "xmlbuilder": "^15.1.1",
-        "yargs": "^16.2.0"
+        "yargs": "^17.7.2"
       },
       "bin": {
         "jsii-pacmak": "bin/jsii-pacmak"
@@ -8466,19 +7551,21 @@
         "node": ">= 14.17.0"
       },
       "peerDependencies": {
-        "jsii-rosetta": ">=5.5.0"
+        "jsii-rosetta": ">=5.7.0"
       }
     },
-    "node_modules/jsii-pacmak/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+    "node_modules/jsii-pacmak/node_modules/@jsii/check-node": {
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.125.0.tgz",
+      "integrity": "sha512-vhFFXFiq2JPE7KoUC54/VsASiuWMu0+rS3BExteIZ3zGu8TdcSLh9aHbfYbww5MjpDTWxxW8TgXumgFTSlyT0Q==",
       "dev": true,
-      "license": "ISC",
+      "license": "Apache-2.0",
       "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
+        "chalk": "^4.1.2",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
       }
     },
     "node_modules/jsii-pacmak/node_modules/escape-string-regexp": {
@@ -8507,93 +7594,51 @@
         "node": ">=10"
       }
     },
-    "node_modules/jsii-pacmak/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jsii-pacmak/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jsii-reflect": {
-      "version": "1.112.0",
-      "resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.112.0.tgz",
-      "integrity": "sha512-B7agb4kmmtW9KHk1KJyB0AHaAs28pOt3FF/yKuDSfJyFZnqh26pbd5ok6Y5jx0qVYcaTydil7FkTF7gRwBz7nQ==",
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.125.0.tgz",
+      "integrity": "sha512-GV8w5oCFB8xWqpri3QM2F1DuEj22ookGzUvGqnB4TNuPSveWsdwZXu9VFnRoDETjnUXkUYEk7hK1cpfp9te6Bg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsii/check-node": "1.112.0",
-        "@jsii/spec": "^1.112.0",
+        "@jsii/check-node": "1.125.0",
+        "@jsii/spec": "1.125.0",
         "chalk": "^4",
         "fs-extra": "^10.1.0",
-        "oo-ascii-tree": "^1.112.0",
-        "yargs": "^16.2.0"
+        "oo-ascii-tree": "^1.125.0",
+        "yargs": "^17.7.2"
       },
       "bin": {
+        "jsii-query": "bin/jsii-query",
         "jsii-tree": "bin/jsii-tree"
       },
       "engines": {
         "node": ">= 14.17.0"
       }
     },
-    "node_modules/jsii-reflect/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+    "node_modules/jsii-reflect/node_modules/@jsii/check-node": {
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.125.0.tgz",
+      "integrity": "sha512-vhFFXFiq2JPE7KoUC54/VsASiuWMu0+rS3BExteIZ3zGu8TdcSLh9aHbfYbww5MjpDTWxxW8TgXumgFTSlyT0Q==",
       "dev": true,
-      "license": "ISC",
+      "license": "Apache-2.0",
       "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/jsii-reflect/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "chalk": "^4.1.2",
+        "semver": "^7.7.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 14.17.0"
       }
     },
-    "node_modules/jsii-reflect/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+    "node_modules/jsii-reflect/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
         "node": ">=10"
       }
@@ -8604,7 +7649,6 @@
       "integrity": "sha512-bVVi4638FUeRHzHYu13yZGqgaaWeegHIPs2Sx+F8bvicWWtC8BQlQvKIsnErnd4+yRKxC+J0g+7EQrHA+8qT8w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@jsii/check-node": "1.112.0",
         "@jsii/spec": "^1.112.0",
@@ -8627,13 +7671,53 @@
         "node": ">= 18.12.0"
       }
     },
+    "node_modules/jsii-rosetta/node_modules/jsii": {
+      "version": "5.8.27",
+      "resolved": "https://registry.npmjs.org/jsii/-/jsii-5.8.27.tgz",
+      "integrity": "sha512-eNaWgp47+b32pYgmlS9gu1UzyNe5FOs+0+2/ta26LCTjP1QItSpQelWbEZZSCl5wT6SnzOh2/5ADJVCpItxIhw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsii/check-node": "1.124.0",
+        "@jsii/spec": "^1.124.0",
+        "case": "^1.6.3",
+        "chalk": "^4",
+        "fast-deep-equal": "^3.1.3",
+        "log4js": "^6.9.1",
+        "semver": "^7.7.3",
+        "semver-intersect": "^1.5.0",
+        "sort-json": "^2.0.1",
+        "spdx-license-list": "^6.10.0",
+        "typescript": "~5.8",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jsii": "bin/jsii"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      }
+    },
+    "node_modules/jsii-rosetta/node_modules/jsii/node_modules/@jsii/check-node": {
+      "version": "1.124.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.124.0.tgz",
+      "integrity": "sha512-Po3BMOyYOB4H8SM/x3Uuvr/inmQCJp58NgC/iYZoDaDz46ukRdTjn6SrdorFrChLrykqf9DMnLOOoFnrPaod7g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
+      }
+    },
     "node_modules/jsii-rosetta/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8647,7 +7731,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8656,10 +7739,37 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/jsii/node_modules/@jsii/check-node": {
+      "version": "1.124.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.124.0.tgz",
+      "integrity": "sha512-Po3BMOyYOB4H8SM/x3Uuvr/inmQCJp58NgC/iYZoDaDz46ukRdTjn6SrdorFrChLrykqf9DMnLOOoFnrPaod7g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
+      }
+    },
+    "node_modules/jsii/node_modules/@jsii/spec": {
+      "version": "1.124.0",
+      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.124.0.tgz",
+      "integrity": "sha512-Mw5uS6490EVZk275zYl1jCt6RH8AWAd9zIsebmeE+Y15GR4Ps6sqKxSAidzoH6Fnem+3TtWJTERpcrBT2iDHiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.17.1"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
+      }
+    },
     "node_modules/jsii/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8670,9 +7780,9 @@
       }
     },
     "node_modules/jsii/node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -8711,9 +7821,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8935,7 +8045,6 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -9145,6 +8254,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nise": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
@@ -9342,9 +8458,9 @@
       }
     },
     "node_modules/oo-ascii-tree": {
-      "version": "1.112.0",
-      "resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.112.0.tgz",
-      "integrity": "sha512-qQH4jZSdabcKpwcqvJTi7eQL86UucvMacbaHiiIrOynT8jhTLtKS2ixaXgGlNBMeN9UhFi1wS00Hnxhw9aYLsA==",
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.125.0.tgz",
+      "integrity": "sha512-wrCjLv3vuGFx1nhLJsP8N8Ejvgr9ImBiRmQiP55msGP1xqU8SU7LOG57SgAtOLjFHnFZTXaUBaxbxK+MSONodg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -9352,17 +8468,17 @@
       }
     },
     "node_modules/openapi-typescript": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.8.0.tgz",
-      "integrity": "sha512-1EeVWmDzi16A+siQlo/SwSGIT7HwaFAVjvMA7/jG5HMLSnrUOzPL7uSTRZZa4v/LCRxHTApHKtNY6glApEoiUQ==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.10.1.tgz",
+      "integrity": "sha512-rBcU8bjKGGZQT4K2ekSTY2Q5veOQbVG/lTKZ49DeCyT9z62hM2Vj/LLHjDHC9W7LJG8YMHcdXpRZDqC1ojB/lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@redocly/openapi-core": "^1.34.3",
+        "@redocly/openapi-core": "^1.34.5",
         "ansi-colors": "^4.1.3",
         "change-case": "^5.4.4",
         "parse-json": "^8.3.0",
-        "supports-color": "^10.0.0",
+        "supports-color": "^10.2.2",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -9391,9 +8507,9 @@
       }
     },
     "node_modules/openapi-typescript/node_modules/supports-color": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.0.0.tgz",
-      "integrity": "sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9601,9 +8717,9 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -9618,11 +8734,11 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
-      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
@@ -9770,22 +8886,22 @@
       }
     },
     "node_modules/publib": {
-      "version": "0.2.999",
-      "resolved": "https://registry.npmjs.org/publib/-/publib-0.2.999.tgz",
-      "integrity": "sha512-zpS/UR5JCEmS3s58y+IqrMCxH/wLyYlIlNqbkEMcWGl36bgGw/feUYf2go43NMgDHVqwTqkcigeivRuLwBFQCw==",
+      "version": "0.2.1027",
+      "resolved": "https://registry.npmjs.org/publib/-/publib-0.2.1027.tgz",
+      "integrity": "sha512-di+xXa7uv/8FYtLxnJRJSt0P1P/mQJZIzHLJC00cNLAtOekK1VNBB166LebbOnXBMJfNLipkMeqmty/8fwqsTA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-codeartifact": "^3.828.0",
-        "@aws-sdk/credential-providers": "^3.828.0",
-        "@aws-sdk/types": "^3.821.0",
+        "@aws-sdk/client-codeartifact": "^3.962.0",
+        "@aws-sdk/credential-providers": "^3.962.0",
+        "@aws-sdk/types": "^3.957.0",
         "@types/fs-extra": "^8.0.0",
         "fs-extra": "^8.0.0",
         "glob": "10.0.0",
         "p-queue": "6",
         "shlex": "^2.1.2",
         "yargs": "^17",
-        "zx": "^8.5.5"
+        "zx": "^8.8.5"
       },
       "bin": {
         "jsii-release": "bin/jsii-release-shim",
@@ -9955,8 +9071,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/randomatic": {
       "version": "3.1.1",
@@ -10488,7 +9603,6 @@
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -10502,14 +9616,14 @@
       "license": "MIT"
     },
     "node_modules/rimraf": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
-      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+      "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "glob": "^11.0.0",
-        "package-json-from-dist": "^1.0.0"
+        "glob": "^13.0.0",
+        "package-json-from-dist": "^1.0.1"
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
@@ -10521,32 +9635,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
-      "integrity": "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^4.0.1",
-        "minimatch": "^10.0.0",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
         "node": "20 || >=22"
@@ -10556,13 +9654,13 @@
       }
     },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "@isaacs/brace-expansion": "^5.0.0"
       },
       "engines": {
         "node": "20 || >=22"
@@ -10591,7 +9689,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -11081,8 +10178,7 @@
       "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
       "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/stream-json": {
       "version": "1.9.1",
@@ -11090,7 +10186,6 @@
       "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "stream-chain": "^2.2.5"
       }
@@ -11191,37 +10286,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -11268,9 +10333,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
       "funding": [
         {
           "type": "github",
@@ -11401,20 +10466,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.3.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.4.tgz",
-      "integrity": "sha512-Iqbrm8IXOmV+ggWHOTEbjwyCf2xZlUMv5npExksXohL+tk8va4Fjhb+X2+Rt9NBmgO7bJ8WpnMLOwih/DnMlFA==",
+      "version": "29.4.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
+      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
-        "ejs": "^3.1.10",
         "fast-json-stable-stringify": "^2.1.0",
-        "jest-util": "^29.0.0",
+        "handlebars": "^4.7.8",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.2",
+        "semver": "^7.7.3",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -11426,10 +10490,11 @@
       },
       "peerDependencies": {
         "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/transform": "^29.0.0",
-        "@jest/types": "^29.0.0",
-        "babel-jest": "^29.0.0",
-        "jest": "^29.0.0",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
         "typescript": ">=4.3 <6"
       },
       "peerDependenciesMeta": {
@@ -11447,13 +10512,16 @@
         },
         "esbuild": {
           "optional": true
+        },
+        "jest-util": {
+          "optional": true
         }
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -11482,6 +10550,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11556,6 +10625,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11564,10 +10634,24 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -11690,13 +10774,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/uri-js-replace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
-      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -11721,20 +10798,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -11784,34 +10847,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/workerpool": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
       "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
@@ -11878,9 +10928,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -11888,6 +10938,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yaml-ast-parser": {
@@ -11950,9 +11003,9 @@
       }
     },
     "node_modules/zx": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/zx/-/zx-8.5.5.tgz",
-      "integrity": "sha512-kzkjV3uqyEthw1IBDbA7Co2djji77vCP1DRvt58aYSMwiX4nyvAkFE8OBSEsOUbDJAst0Yo4asNvMTGG5HGPXA==",
+      "version": "8.8.5",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-8.8.5.tgz",
+      "integrity": "sha512-SNgDF5L0gfN7FwVOdEFguY3orU5AkfFZm9B5YSHog/UDHv+lvmd82ZAsOenOkQixigwH2+yyH198AwNdKhj+RA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cxbuilder/flow-config",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Amazon Connect third-party app for configuring variables and prompts in Connect contact flows",
   "author": {
@@ -54,38 +54,38 @@
     "seed": "ts-node scripts/seed-dynamodb.ts"
   },
   "devDependencies": {
-    "@aws-lambda-powertools/logger": "^2.21.0",
-    "@types/aws-lambda": "^8.10.149",
+    "@aws-lambda-powertools/logger": "^2.30.0",
+    "@types/aws-lambda": "^8.10.159",
     "@types/jest": "^29.5.14",
     "@types/mime-types": "^2.1.4",
-    "@types/node": "22.7.9",
-    "aws-cdk": "2.1014.0",
-    "aws-cdk-lib": "2.194.0",
+    "@types/node": "22.15.32",
+    "aws-cdk": "2.1100.2",
+    "aws-cdk-lib": "2.233.0",
     "aws-sdk-client-mock": "^4.1.0",
     "aws-sdk-client-mock-jest": "^4.1.0",
-    "constructs": "10.0.0",
+    "constructs": "10.4.4",
     "cpx": "^1.5.0",
-    "esbuild": "^0.25.5",
+    "esbuild": "^0.25.12",
     "jest": "^29.7.0",
-    "jsii": "^5.8.12",
-    "jsii-pacmak": "^1.112.0",
-    "openapi-typescript": "^7.4.3",
-    "publib": "^0.2.999",
-    "rimraf": "^6.0.1",
-    "ts-jest": "^29.2.5",
+    "jsii": "^5.9.22",
+    "jsii-pacmak": "^1.125.0",
+    "openapi-typescript": "^7.10.1",
+    "publib": "^0.2.1027",
+    "rimraf": "^6.1.2",
+    "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
     "typescript": "~5.6.3"
   },
   "dependencies": {
-    "@aws-sdk/client-cloudformation": "^3.826.0",
-    "@aws-sdk/client-connect": "^3.826.0",
-    "@aws-sdk/client-dynamodb": "^3.826.0",
-    "@aws-sdk/client-lambda": "^3.826.0",
-    "@aws-sdk/client-polly": "^3.826.0",
-    "@aws-sdk/client-sns": "^3.826.0",
-    "@aws-sdk/lib-dynamodb": "^3.826.0",
+    "@aws-sdk/client-cloudformation": "^3.962.0",
+    "@aws-sdk/client-connect": "^3.962.0",
+    "@aws-sdk/client-dynamodb": "^3.962.0",
+    "@aws-sdk/client-lambda": "^3.962.0",
+    "@aws-sdk/client-polly": "^3.962.0",
+    "@aws-sdk/client-sns": "^3.962.0",
+    "@aws-sdk/lib-dynamodb": "^3.962.0",
     "mime-types": "^2.1.35",
-    "yaml": "^2.8.0"
+    "yaml": "^2.8.2"
   },
   "bundledDependencies": [
     "@aws-sdk/client-cloudformation",
@@ -99,7 +99,7 @@
     "yaml"
   ],
   "peerDependencies": {
-    "aws-cdk-lib": "2.194.0",
+    "aws-cdk-lib": "2.233.0",
     "constructs": "^10.0.0"
   },
   "stability": "stable",
@@ -126,6 +126,6 @@
   },
   "homepage": "https://github.com/cxbuilder/flow-config#readme",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Update all backend and frontend npm dependencies to their latest minor versions
- All tests pass and CDK synth completes successfully
- No breaking changes introduced

## Backend Package Updates

| Package | Old Version | New Version |
|---------|-------------|-------------|
| @aws-lambda-powertools/logger | ^2.21.0 | ^2.30.0 |
| @types/aws-lambda | ^8.10.149 | ^8.10.159 |
| @types/node | 22.7.9 | 22.15.32 |
| constructs | 10.0.0 | 10.4.4 |
| esbuild | ^0.25.5 | ^0.25.12 |
| jsii | ^5.8.12 | ^5.9.22 |
| jsii-pacmak | ^1.112.0 | ^1.125.0 |
| openapi-typescript | ^7.4.3 | ^7.10.1 |
| publib | ^0.2.999 | ^0.2.1027 |
| rimraf | ^6.0.1 | ^6.1.2 |
| ts-jest | ^29.2.5 | ^29.4.6 |
| @aws-sdk/* packages | ^3.826.0 | ^3.962.0 |
| yaml | ^2.8.0 | ^2.8.2 |

## Frontend Package Updates

| Package | Old Version | New Version |
|---------|-------------|-------------|
| @amazon-connect/theme | ^1.0.3 | 1.0.6 (pinned) |
| @cloudscape-design/components | ^3.0.827 | ^3.0.1167 |
| @cloudscape-design/global-styles | ^1.0.32 | ^1.0.49 |
| react | ^19.1.0 | ^19.2.3 |
| react-dom | ^19.1.0 | ^19.2.3 |
| @eslint/js | ^9.25.0 | ^9.39.2 |
| @types/react | ^19.1.2 | ^19.2.7 |
| @types/react-dom | ^19.1.2 | ^19.2.3 |
| @vitejs/plugin-react | ^4.4.1 | ^4.7.0 |
| eslint | ^9.25.0 | ^9.39.2 |
| eslint-plugin-react-refresh | ^0.4.19 | ^0.4.26 |
| globals | ^16.0.0 | ^16.5.0 |
| typescript-eslint | ^8.30.1 | ^8.52.0 |
| vite | ^6.3.5 | ^6.4.1 |

## Notes
- **@amazon-connect/theme** was pinned to `1.0.6` because versions ≥1.0.7 introduce a dependency on `@amazon-connect/core` which is not available as a standalone package and breaks the build
- New CDK warnings about `fromAwsManagedPolicyName` metadata are informational only and don't affect functionality

## Test plan
- [x] All 61 backend tests pass
- [x] CDK synth completes successfully
- [x] Frontend build completes successfully